### PR TITLE
fix: set actual KV namespace ID for OAUTH_KV

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,7 +16,7 @@ new_sqlite_classes = ["RagMcpAgent", "IssueStore"]
 # KV namespace for OAuth provider (token, client, grant storage)
 [[kv_namespaces]]
 binding = "OAUTH_KV"
-id = "placeholder-replace-after-kv-create"
+id = "67611ab57f734f1c9a0b5d5a96f65e78"
 
 # Vectorize index for semantic search
 [[vectorize]]


### PR DESCRIPTION
## Summary

wrangler.toml の OAUTH_KV バインディングにプレースホルダー値が残っていたため、実際の KV namespace ID に置換。

## Test plan

- [x] `wrangler deploy` 成功確認済み