### PR TITLE
fix: export scheduled handler and add POLL_REPOS to wrangler.toml

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,14 @@ const innerHandler: ExportedHandler<Env> = {
 
 // OAuthProvider wraps the inner handler, adding OAuth endpoints
 // and protecting /mcp route with access token validation.
-export default createOAuthProvider(
+// Note: OAuthProvider only wraps fetch. We re-export scheduled separately.
+const oauthWrapped = createOAuthProvider(
   innerHandler as unknown as ExportedHandler<OAuthEnv & Record<string, unknown>>,
 );
+
+export default {
+  fetch: oauthWrapped.fetch,
+  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    await handleScheduled(controller, env, ctx);
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,5 +36,6 @@ crons = ["*/5 * * * *"]
 # GITHUB_CLIENT_SECRET   — GitHub App OAuth client secret
 # GITHUB_TOKEN           — GitHub token for API polling (PAT or installation token)
 
-# Environment variables (set via `wrangler secret put` or [vars] for non-secret):
-# POLL_REPOS             — Comma-separated repos to poll, e.g. "owner/repo1,owner/repo2"
+# Environment variables
+[vars]
+POLL_REPOS = "Liplus-Project/github-webhook-mcp,Liplus-Project/github-rag-mcp,Liplus-Project/liplus-desktop,Liplus-Project/liplus-language"


### PR DESCRIPTION
## Summary

- OAuthProvider が scheduled ハンドラを落としていたため Cron Trigger が動作しなかった問題を修正
- POLL_REPOS を wrangler.toml の [vars] に移動（wrangler deploy で Dashboard 設定が消える問題の防止）

## Test plan

- [x] `wrangler deploy` 成功
- [ ] 次の Cron 実行でポーリングが成功することをログで確認