### PR TITLE
fix(worker): wrap OAuthProvider.fetch to preserve this binding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,8 @@ const oauthWrapped = createOAuthProvider(
 );
 
 export default {
-  fetch: oauthWrapped.fetch,
+  fetch: (req: Request, env: Env, ctx: ExecutionContext) =>
+    oauthWrapped.fetch(req, env as unknown as OAuthEnv & Record<string, unknown>, ctx),
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
     await handleScheduled(controller, env, ctx);
   },


### PR DESCRIPTION
Refs #11

OAuthProvider の fetch メソッドをプロパティ参照でエクスポートすると、内部の private member (#impl) への this バインディングが失われ、Worker の GET / が 500 (error code: 1101) を返していた。ラムダラップで this コンテキストを保持するよう修正。