### PR TITLE
fix(cd): rename mcpb artifact to github-rag-mcp.mcpb

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,11 +38,13 @@ jobs:
         with:
           name: mcpb
           path: dist
-      - name: Upload mcpb to release
+      - name: Rename and upload mcpb to release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG_NAME" dist/*.mcpb --clobber --repo "${{ github.repository }}"
+        run: |
+          mv dist/mcp-server.mcpb dist/github-rag-mcp.mcpb
+          gh release upload "$TAG_NAME" dist/github-rag-mcp.mcpb --clobber --repo "${{ github.repository }}"
 
   npm-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CDワークフローのattach-mcpbステップで、成果物名をmcp-server.mcpbからgithub-rag-mcp.mcpbにリネームしてアップロードするよう修正。