### PR TITLE
fix(manifest): add icon field

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -17,6 +17,7 @@
   "documentation": "https://github.com/Liplus-Project/github-rag-mcp#readme",
   "support": "https://github.com/Liplus-Project/github-rag-mcp/discussions",
   "license": "MIT",
+  "icon": "icon.png",
   "server": {
     "type": "node",
     "entry_point": "server/index.js",


### PR DESCRIPTION
manifest.jsonにicon参照フィールドを追加。
icon.pngは既にリポジトリに存在するが、manifestから参照されていなかった。