### PR TITLE
chore: add dipper_ai to POLL_REPOS

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,4 +38,4 @@ crons = ["*/5 * * * *"]
 
 # Environment variables
 [vars]
-POLL_REPOS = "Liplus-Project/github-webhook-mcp,Liplus-Project/github-rag-mcp,Liplus-Project/liplus-desktop,Liplus-Project/liplus-language"
+POLL_REPOS = "Liplus-Project/github-webhook-mcp,Liplus-Project/github-rag-mcp,Liplus-Project/liplus-desktop,Liplus-Project/liplus-language,Liplus-Project/dipper_ai"


### PR DESCRIPTION
## Summary
- Add `Liplus-Project/dipper_ai` to `POLL_REPOS` in wrangler.toml so the polling worker indexes dipper_ai issues/PRs.

## Test plan
- Verify Cloudflare Worker deploys successfully and polls the new repo on next cron cycle.