### PR TITLE
Add CI workflow for TypeScript check and wrangler dry-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npx wrangler deploy --dry-run --outdir dist
+
+  # Gate job: single Required status check for branch protection.
+  # Add new jobs to `needs` when CI grows. No Settings change needed.
+  CI:
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "CI failed: test=${{ needs.test.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
Refs #23

CI ワークフローを追加し、PR マージ前に TypeScript 構文チェック (`tsc --noEmit`) と
`wrangler deploy --dry-run` によるビルド検証を実行できるようにした。
Gate ジョブ (CI) により required status check 設定が容易になる。