### PR TITLE
Fix NOTICE copyright holder name

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 github-rag-mcp
-Copyright 2026 Liplus Project
+Copyright 2026 Yoshiharu Uematsu


### PR DESCRIPTION
Refs #27

NOTICEファイルの著作権者表記を "Liplus Project" から "Yoshiharu Uematsu" に修正。