### PR TITLE
feat: add release information to search, context, and activity tools

### DIFF
--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -59,6 +59,24 @@ Polling strategy:
   - `cache: "no-store"` on fetch() to bypass Cloudflare cache layer
   - ETag stored alongside watermark in Durable Object
 
+### 1b. Release Poller
+
+Runs as part of the cron poller, after issue/PR polling for each repository.
+
+Responsibilities:
+- Fetch release updates from GitHub Releases API
+- Detect new and updated releases
+- Generate embeddings for release name + body (release notes)
+- Upsert vectors into Vectorize with release-specific metadata
+- Store structured release data in Durable Object (releases table)
+
+Polling strategy:
+- Use ETag conditional requests (`If-None-Match`) to skip processing when no changes
+  - Same pattern as issue/PR polling (#38)
+  - 304 Not Modified skips all downstream processing
+- Separate watermark namespace: `releases:{repo}` in watermarks table
+- Vector ID format: `{repo}#release-{tag_name}` (no collision with `{repo}#{number}`)
+
 ### 2. Embedding Pipeline
 
 Model: `@cf/baai/bge-m3` (Workers AI)
@@ -73,13 +91,14 @@ Embedding triggers:
 
 Vector metadata (stored alongside embedding in Vectorize):
 - `repo` (string) — repository full name (owner/repo)
-- `number` (number) — issue/PR number
-- `type` (string) — "issue" or "pull_request"
-- `state` (string) — "open" or "closed"
-- `labels` (string) — comma-separated label names
-- `milestone` (string) — milestone title or empty
-- `assignees` (string) — comma-separated login names
+- `number` (number) — issue/PR number (0 for releases)
+- `type` (string) — "issue", "pull_request", or "release"
+- `state` (string) — "open" or "closed" (releases: always "published")
+- `labels` (string) — comma-separated label names (releases: empty)
+- `milestone` (string) — milestone title or empty (releases: empty)
+- `assignees` (string) — comma-separated login names (releases: empty)
 - `updated_at` (string) — ISO 8601 timestamp
+- `tag_name` (string) — release tag name (releases only, empty for issues/PRs)
 
 ### 3. MCP Server
 
@@ -97,11 +116,12 @@ Parameters:
 - `labels` (string[], optional) — filter by label names (AND logic)
 - `milestone` (string, optional) — filter by milestone title
 - `assignee` (string, optional) — filter by assignee login
-- `type` (string, optional) — "issue" | "pull_request" | "all" (default: "all")
+- `type` (string, optional) — "issue" | "pull_request" | "release" | "all" (default: "all")
 - `top_k` (number, optional) — max results (default: 10, max: 50)
 
 Returns:
-- Array of matched issues/PRs with: number, title, state, labels, milestone, assignee, score, url, updated_at
+- Array of matched issues/PRs/releases with: number, title, state, labels, milestone, assignee, score, url, updated_at
+- Releases include: tag_name, prerelease flag
 
 Flow:
 1. Generate embedding for `query` via Workers AI
@@ -123,6 +143,7 @@ Returns:
 - Branch status (name, ahead/behind)
 - Latest CI status (workflow name, conclusion, url)
 - Sub-issues (if parent issue)
+- Related releases (releases published after issue was closed, linking issue to release)
 
 Flow:
 1. Read issue state from Durable Object cache
@@ -140,6 +161,7 @@ Parameters:
 
 Returns:
 - Array of activity items: type (created/updated/closed), number, title, actor, timestamp, url
+- Includes release activity (type: "release", activity_type: "created")
 
 Flow:
 1. Query Durable Object for issues/PRs with `updated_at >= since`
@@ -166,8 +188,9 @@ GitHub App (same pattern as github-webhook-mcp):
 
 SQLite-backed structured storage:
 - Issue/PR metadata (number, title, state, labels, milestone, assignees, body hash, timestamps)
-- Polling watermarks (last polled timestamp per repo)
-- Used for `get_issue_context` and `list_recent_activity` without hitting Vectorize
+- Release metadata (tag_name, name, prerelease, body hash, timestamps)
+- Polling watermarks (last polled timestamp per repo; releases use `releases:{repo}` key)
+- Used for `get_issue_context`, `list_recent_activity`, and release queries without hitting Vectorize
 
 ## Constraints
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -14,7 +14,7 @@
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { Env, IssueRecord, VectorMetadata } from "./types.js";
+import type { Env, IssueRecord, ReleaseRecord, VectorMetadata } from "./types.js";
 import type { GitHubUserProps } from "./oauth.js";
 
 /** User context passed via props from OAuth layer */
@@ -77,7 +77,7 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
     // ── search_issues ──────────────────────────────────────────
     this.server.tool(
       "search_issues",
-      "Semantic search for GitHub issues and PRs combined with structured filters. " +
+      "Semantic search for GitHub issues, PRs, and releases combined with structured filters. " +
         "Uses embedding similarity (BGE-M3) with optional metadata filters.",
       {
         query: z.string().describe("Natural language search query"),
@@ -103,10 +103,10 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
           .optional()
           .describe("Filter by assignee login"),
         type: z
-          .enum(["issue", "pull_request", "all"])
+          .enum(["issue", "pull_request", "release", "all"])
           .optional()
           .default("all")
-          .describe("Filter by type"),
+          .describe("Filter by type (default: all)"),
         top_k: z
           .number()
           .min(1)
@@ -183,27 +183,53 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
           const meta = m.metadata as unknown as VectorMetadata | undefined;
           const itemRepo = meta?.repo ?? "";
           const number = meta?.number ?? 0;
+          const itemType = meta?.type ?? "";
+          const tagName = meta?.tag_name ?? "";
+
+          // Build URL based on type
+          let url: string;
+          if (itemType === "release" && tagName) {
+            url = `https://github.com/${itemRepo}/releases/tag/${tagName}`;
+          } else {
+            url = `https://github.com/${itemRepo}/issues/${number}`;
+          }
+
           return {
             number,
-            title: "", // Title not stored in Vectorize metadata; enriched below
+            title: "", // Enriched below
             state: meta?.state ?? "",
-            type: meta?.type ?? "",
+            type: itemType,
             labels: meta?.labels ? meta.labels.split(",").filter(Boolean) : [],
             milestone: meta?.milestone ?? "",
             assignees: meta?.assignees
               ? meta.assignees.split(",").filter(Boolean)
               : [],
             score: m.score,
-            url: `https://github.com/${itemRepo}/issues/${number}`,
+            url,
             updated_at: meta?.updated_at ?? "",
             repo: itemRepo,
+            ...(itemType === "release" ? { tag_name: tagName } : {}),
           };
         });
 
-        // Enrich with titles from IssueStore
+        // Enrich with titles from IssueStore / release store
         const store = this.getStore();
         for (const item of items) {
-          if (item.repo && item.number) {
+          if (item.type === "release" && item.repo && (item as Record<string, unknown>).tag_name) {
+            try {
+              const res = await store.fetch(
+                new Request(
+                  `http://store/release?repo=${encodeURIComponent(item.repo)}&tag_name=${encodeURIComponent((item as Record<string, unknown>).tag_name as string)}`,
+                ),
+              );
+              if (res.ok) {
+                const record = (await res.json()) as ReleaseRecord;
+                item.title = record.name || record.tagName;
+              }
+            } catch {
+              // Best-effort enrichment
+            }
+          } else if (item.repo && item.number) {
             try {
               const res = await store.fetch(
                 new Request(
@@ -403,7 +429,43 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
           // Sub-issues API may not be available
         }
 
-        // 6. Aggregate result
+        // 6. Find related releases (for closed issues, find releases published after close)
+        let relatedReleases: Array<{
+          tag_name: string;
+          name: string;
+          prerelease: boolean;
+          published_at: string;
+          url: string;
+        }> = [];
+
+        const issueState = issueData?.state ?? (ghIssue as Record<string, unknown> | null)?.state ?? "";
+        if (issueState === "closed") {
+          // Use updated_at as proxy for close time
+          const closeTime = issueData?.updatedAt ?? "";
+          if (closeTime) {
+            try {
+              const releasesRes = await store.fetch(
+                new Request(
+                  `http://store/releases-after?repo=${encodeURIComponent(repo)}&after=${encodeURIComponent(closeTime)}&limit=3`,
+                ),
+              );
+              if (releasesRes.ok) {
+                const releases = (await releasesRes.json()) as ReleaseRecord[];
+                relatedReleases = releases.map((r) => ({
+                  tag_name: r.tagName,
+                  name: r.name,
+                  prerelease: r.prerelease,
+                  published_at: r.publishedAt,
+                  url: `https://github.com/${repo}/releases/tag/${r.tagName}`,
+                }));
+              }
+            } catch {
+              // Non-critical
+            }
+          }
+        }
+
+        // 7. Aggregate result
         const result = {
           repo,
           number,
@@ -421,6 +483,7 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
           branch: branchStatus,
           ci: ciStatus,
           sub_issues: subIssues,
+          releases: relatedReleases,
         };
 
         return {
@@ -434,7 +497,7 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
     // ── list_recent_activity ───────────────────────────────────
     this.server.tool(
       "list_recent_activity",
-      "List recent issue/PR activity across tracked repositories. " +
+      "List recent issue/PR/release activity across tracked repositories. " +
         "Returns changes classified as created, updated, or closed.",
       {
         repo: z
@@ -488,7 +551,7 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
         const records = (await res.json()) as IssueRecord[];
 
         // Classify activity and format results
-        const activities = records.map((record) => ({
+        const activities: Array<Record<string, unknown>> = records.map((record) => ({
           activity_type: classifyActivity(record, effectiveSince),
           number: record.number,
           title: record.title,
@@ -501,15 +564,55 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
           created_at: record.createdAt,
         }));
 
+        // Fetch recent releases too
+        const releaseParams = new URLSearchParams();
+        releaseParams.set("since", effectiveSince);
+        releaseParams.set("limit", String(effectiveLimit));
+        if (repo) {
+          releaseParams.set("repo", repo);
+        }
+
+        const releaseRes = await store.fetch(
+          new Request(`http://store/recent-releases?${releaseParams.toString()}`),
+        );
+
+        if (releaseRes.ok) {
+          const releases = (await releaseRes.json()) as ReleaseRecord[];
+          for (const release of releases) {
+            activities.push({
+              activity_type: "created",
+              number: 0,
+              title: release.name || release.tagName,
+              type: "release",
+              state: "published",
+              labels: [],
+              repo: release.repo,
+              tag_name: release.tagName,
+              prerelease: release.prerelease,
+              url: `https://github.com/${release.repo}/releases/tag/${release.tagName}`,
+              updated_at: release.publishedAt,
+              created_at: release.createdAt,
+            });
+          }
+        }
+
+        // Sort combined activities by updated_at descending and apply limit
+        activities.sort((a, b) => {
+          const aTime = (a.updated_at as string) ?? "";
+          const bTime = (b.updated_at as string) ?? "";
+          return bTime.localeCompare(aTime);
+        });
+        const limitedActivities = activities.slice(0, effectiveLimit);
+
         return {
           content: [
             {
               type: "text" as const,
               text: JSON.stringify(
                 {
-                  count: activities.length,
+                  count: limitedActivities.length,
                   since: effectiveSince,
-                  activities,
+                  activities: limitedActivities,
                 },
                 null,
                 2,

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -7,7 +7,7 @@
  * Stores structured metadata in IssueStore Durable Object.
  */
 
-import type { Env, IssueRecord } from "./types.js";
+import type { Env, IssueRecord, ReleaseRecord } from "./types.js";
 
 /** GitHub API issue/PR response shape (subset of fields we need) */
 interface GitHubIssue {
@@ -444,6 +444,223 @@ async function pollRepo(
   );
 }
 
+// ── Release Polling ────────────────────────────────────────
+
+/** GitHub API release response shape (subset of fields we need) */
+interface GitHubRelease {
+  id: number;
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  prerelease: boolean;
+  created_at: string;
+  published_at: string | null;
+  html_url: string;
+}
+
+/**
+ * Fetch releases from GitHub API with ETag conditional request support.
+ * Returns the releases array and the response ETag.
+ * When `etag` is provided, sends `If-None-Match` header.
+ * If GitHub responds 304 Not Modified, returns NOT_MODIFIED sentinel.
+ */
+async function fetchReleases(
+  repo: string,
+  token: string,
+  etag?: string,
+): Promise<{ releases: GitHubRelease[]; etag?: string } | typeof NOT_MODIFIED> {
+  const url = new URL(`https://api.github.com/repos/${repo}/releases`);
+  url.searchParams.set("per_page", "100");
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "github-rag-mcp/0.1.0",
+  };
+
+  if (etag) {
+    headers["If-None-Match"] = etag;
+  }
+
+  const resp = await fetch(url.toString(), {
+    headers,
+    cache: "no-store",
+  } as RequestInit);
+
+  if (resp.status === 304) {
+    return NOT_MODIFIED;
+  }
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`GitHub Releases API error ${resp.status}: ${text}`);
+  }
+
+  const releases = (await resp.json()) as GitHubRelease[];
+  const responseEtag = resp.headers.get("etag") ?? undefined;
+  return { releases, etag: responseEtag };
+}
+
+/**
+ * Build Vectorize vector ID for a release.
+ * Format: "owner/repo#release-v1.0.0"
+ */
+function releaseVectorId(repo: string, tagName: string): string {
+  return `${repo}#release-${tagName}`;
+}
+
+/**
+ * Poll a single repository for release updates.
+ */
+async function pollReleases(
+  repo: string,
+  env: Env,
+  storeStub: DurableObjectStub,
+): Promise<void> {
+  // Use a separate watermark namespace for releases
+  const watermarkKey = `releases:${repo}`;
+  const wmResp = await storeStub.fetch(
+    new Request(
+      `http://store/watermark?repo=${encodeURIComponent(watermarkKey)}`,
+    ),
+  );
+
+  let storedEtag: string | undefined;
+  if (wmResp.ok) {
+    const wm = (await wmResp.json()) as { repo: string; lastPolledAt: string; etag?: string };
+    storedEtag = wm.etag;
+  }
+
+  console.log(
+    `Polling releases for ${repo}${storedEtag ? " (with ETag)" : ""}`,
+  );
+
+  const result = await fetchReleases(repo, env.GITHUB_TOKEN, storedEtag);
+
+  if (result === NOT_MODIFIED) {
+    console.log(`${repo} releases: 304 Not Modified — no changes`);
+    return;
+  }
+
+  const { releases, etag: responseEtag } = result;
+
+  if (releases.length === 0) {
+    console.log(`No releases for ${repo}`);
+    // Update watermark with new ETag
+    await storeStub.fetch(
+      new Request("http://store/watermark", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repo: watermarkKey, lastPolledAt: new Date().toISOString(), etag: responseEtag }),
+      }),
+    );
+    return;
+  }
+
+  let embedded = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const release of releases) {
+    const body = release.body ?? "";
+    const name = release.name ?? release.tag_name;
+    const bodyHash = await computeBodyHash(name, body);
+
+    // Check if release body has changed
+    const existingResp = await storeStub.fetch(
+      new Request(
+        `http://store/release?repo=${encodeURIComponent(repo)}&tag_name=${encodeURIComponent(release.tag_name)}`,
+      ),
+    );
+
+    let needsEmbedding = true;
+    if (existingResp.ok) {
+      const existing = (await existingResp.json()) as ReleaseRecord;
+      if (existing.bodyHash === bodyHash) {
+        needsEmbedding = false;
+        skipped++;
+      }
+    }
+
+    let embeddingSucceeded = false;
+
+    if (needsEmbedding && embedded >= MAX_EMBEDDINGS_PER_RUN) {
+      // Skip — will retry next cron
+      needsEmbedding = true;
+    }
+
+    if (needsEmbedding && embedded < MAX_EMBEDDINGS_PER_RUN) {
+      try {
+        const embeddingInput = prepareEmbeddingInput(name, body);
+        const embedding = await generateEmbedding(env.AI, embeddingInput);
+
+        const metadata: Record<string, string | number> = {
+          repo,
+          number: 0,
+          type: "release",
+          state: "published",
+          labels: "",
+          milestone: "",
+          assignees: "",
+          updated_at: release.published_at ?? release.created_at,
+          tag_name: release.tag_name,
+        };
+
+        await env.VECTORIZE.upsert([
+          {
+            id: releaseVectorId(repo, release.tag_name),
+            values: embedding,
+            metadata,
+          },
+        ]);
+
+        embeddingSucceeded = true;
+        embedded++;
+      } catch (err) {
+        console.error(
+          `Failed to embed release ${repo}#${release.tag_name}:`,
+          err instanceof Error ? err.message : String(err),
+        );
+        failed++;
+      }
+    }
+
+    // Upsert release record into store
+    const record: ReleaseRecord = {
+      repo,
+      tagName: release.tag_name,
+      name,
+      body,
+      prerelease: release.prerelease,
+      bodyHash: needsEmbedding && !embeddingSucceeded ? "" : bodyHash,
+      createdAt: release.created_at,
+      publishedAt: release.published_at ?? release.created_at,
+    };
+
+    await storeStub.fetch(
+      new Request("http://store/upsert-release", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(record),
+      }),
+    );
+  }
+
+  // Update watermark with ETag
+  await storeStub.fetch(
+    new Request("http://store/watermark", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo: watermarkKey, lastPolledAt: new Date().toISOString(), etag: responseEtag }),
+    }),
+  );
+
+  console.log(
+    `${repo} releases: ${releases.length} total, ${embedded} embedded, ${skipped} unchanged, ${failed} failed`,
+  );
+}
+
 /**
  * Main scheduled handler — called by Cron Trigger every 5 minutes.
  * Polls all configured repositories for issue/PR updates.
@@ -490,6 +707,15 @@ export async function handleScheduled(
         err instanceof Error ? err.message : String(err),
       );
       // Continue polling other repos even if one fails
+    }
+
+    try {
+      await pollReleases(repo, env, storeStub);
+    } catch (err) {
+      console.error(
+        `Failed to poll releases for ${repo}:`,
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,7 +5,7 @@
  * Body text is NOT stored (only body_hash for embedding change detection).
  */
 
-import type { Env, IssueRecord, PollWatermark } from "./types.js";
+import type { Env, IssueRecord, ReleaseRecord, PollWatermark } from "./types.js";
 
 /** Row shape returned by SQLite for the issues table */
 type IssueRow = {
@@ -23,6 +23,19 @@ type IssueRow = {
   updated_at: string;
 };
 
+/** Row shape returned by SQLite for the releases table */
+type ReleaseRow = {
+  [key: string]: SqlStorageValue;
+  repo: string;
+  tag_name: string;
+  name: string;
+  body: string;
+  prerelease: number;
+  body_hash: string;
+  created_at: string;
+  published_at: string;
+};
+
 /** Row shape returned by SQLite for the watermarks table */
 type WatermarkRow = {
   [key: string]: SqlStorageValue;
@@ -30,6 +43,19 @@ type WatermarkRow = {
   last_polled_at: string;
   etag: string;
 };
+
+function rowToReleaseRecord(row: ReleaseRow): ReleaseRecord {
+  return {
+    repo: row.repo,
+    tagName: row.tag_name,
+    name: row.name,
+    body: row.body,
+    prerelease: row.prerelease === 1,
+    bodyHash: row.body_hash,
+    createdAt: row.created_at,
+    publishedAt: row.published_at,
+  };
+}
 
 function rowToIssueRecord(row: IssueRow): IssueRecord {
   return {
@@ -83,6 +109,31 @@ export class IssueStore implements DurableObject {
         last_polled_at TEXT NOT NULL,
         etag           TEXT NOT NULL DEFAULT ''
       );
+    `);
+
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS releases (
+        repo         TEXT    NOT NULL,
+        tag_name     TEXT    NOT NULL,
+        name         TEXT    NOT NULL DEFAULT '',
+        body         TEXT    NOT NULL DEFAULT '',
+        prerelease   INTEGER NOT NULL DEFAULT 0,
+        body_hash    TEXT    NOT NULL DEFAULT '',
+        created_at   TEXT    NOT NULL,
+        published_at TEXT    NOT NULL,
+        PRIMARY KEY (repo, tag_name)
+      );
+    `);
+
+    // Index for recent release queries
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS idx_releases_published
+        ON releases (published_at DESC);
+    `);
+
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS idx_releases_repo
+        ON releases (repo, published_at DESC);
     `);
 
     // Migration: add etag column if missing (existing deployments)
@@ -188,6 +239,88 @@ export class IssueStore implements DurableObject {
     return [...cursor].map(rowToIssueRecord);
   }
 
+  // ---- Release CRUD ----
+
+  upsertRelease(record: ReleaseRecord): void {
+    this.sql.exec(
+      `INSERT INTO releases (repo, tag_name, name, body, prerelease, body_hash, created_at, published_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (repo, tag_name) DO UPDATE SET
+         name         = excluded.name,
+         body         = excluded.body,
+         prerelease   = excluded.prerelease,
+         body_hash    = excluded.body_hash,
+         published_at = excluded.published_at`,
+      record.repo,
+      record.tagName,
+      record.name,
+      record.body,
+      record.prerelease ? 1 : 0,
+      record.bodyHash,
+      record.createdAt,
+      record.publishedAt,
+    );
+  }
+
+  getRelease(repo: string, tagName: string): ReleaseRecord | null {
+    const cursor = this.sql.exec<ReleaseRow>(
+      `SELECT * FROM releases WHERE repo = ? AND tag_name = ?`,
+      repo,
+      tagName,
+    );
+    const rows = [...cursor];
+    if (rows.length === 0) return null;
+    return rowToReleaseRecord(rows[0]);
+  }
+
+  listReleasesByRepo(
+    repo: string,
+    opts?: { limit?: number },
+  ): ReleaseRecord[] {
+    const limit = opts?.limit ?? 50;
+    const cursor = this.sql.exec<ReleaseRow>(
+      `SELECT * FROM releases WHERE repo = ? ORDER BY published_at DESC LIMIT ?`,
+      repo,
+      limit,
+    );
+    return [...cursor].map(rowToReleaseRecord);
+  }
+
+  getRecentReleases(
+    opts?: { since?: string; limit?: number; repo?: string },
+  ): ReleaseRecord[] {
+    const limit = opts?.limit ?? 20;
+    const since = opts?.since ?? new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+    let query: string;
+    let params: (string | number)[];
+
+    if (opts?.repo) {
+      query = `SELECT * FROM releases WHERE repo = ? AND published_at >= ? ORDER BY published_at DESC LIMIT ?`;
+      params = [opts.repo, since, limit];
+    } else {
+      query = `SELECT * FROM releases WHERE published_at >= ? ORDER BY published_at DESC LIMIT ?`;
+      params = [since, limit];
+    }
+
+    const cursor = this.sql.exec<ReleaseRow>(query, ...params);
+    return [...cursor].map(rowToReleaseRecord);
+  }
+
+  /**
+   * Find releases published after a given timestamp (e.g., issue close time).
+   * Used by get_issue_context to find which release an issue was included in.
+   */
+  getReleasesAfter(repo: string, afterTimestamp: string, limit = 5): ReleaseRecord[] {
+    const cursor = this.sql.exec<ReleaseRow>(
+      `SELECT * FROM releases WHERE repo = ? AND published_at >= ? ORDER BY published_at ASC LIMIT ?`,
+      repo,
+      afterTimestamp,
+      limit,
+    );
+    return [...cursor].map(rowToReleaseRecord);
+  }
+
   // ---- Hash reset for re-sync ----
 
   /**
@@ -279,6 +412,65 @@ export class IssueStore implements DurableObject {
         const limit = url.searchParams.get("limit");
         const repo = url.searchParams.get("repo") ?? undefined;
         const items = this.getRecentActivity({
+          since,
+          limit: limit ? parseInt(limit, 10) : undefined,
+          repo,
+        });
+        return Response.json(items);
+      }
+
+      // POST /upsert-release — upsert a single release record
+      if (request.method === "POST" && path === "/upsert-release") {
+        const record = (await request.json()) as ReleaseRecord;
+        this.upsertRelease(record);
+        return new Response("ok", { status: 200 });
+      }
+
+      // GET /release?repo=...&tag_name=... — get a single release
+      if (request.method === "GET" && path === "/release") {
+        const repo = url.searchParams.get("repo");
+        const tagName = url.searchParams.get("tag_name");
+        if (!repo || !tagName) {
+          return new Response("missing repo or tag_name", { status: 400 });
+        }
+        const release = this.getRelease(repo, tagName);
+        if (!release) return new Response("not found", { status: 404 });
+        return Response.json(release);
+      }
+
+      // GET /releases?repo=...&limit=... — list releases by repo
+      if (request.method === "GET" && path === "/releases") {
+        const repo = url.searchParams.get("repo");
+        if (!repo) return new Response("missing repo", { status: 400 });
+        const limit = url.searchParams.get("limit");
+        const releases = this.listReleasesByRepo(repo, {
+          limit: limit ? parseInt(limit, 10) : undefined,
+        });
+        return Response.json(releases);
+      }
+
+      // GET /releases-after?repo=...&after=...&limit=... — releases published after timestamp
+      if (request.method === "GET" && path === "/releases-after") {
+        const repo = url.searchParams.get("repo");
+        const after = url.searchParams.get("after");
+        if (!repo || !after) {
+          return new Response("missing repo or after", { status: 400 });
+        }
+        const limit = url.searchParams.get("limit");
+        const releases = this.getReleasesAfter(
+          repo,
+          after,
+          limit ? parseInt(limit, 10) : undefined,
+        );
+        return Response.json(releases);
+      }
+
+      // GET /recent-releases?since=...&limit=...&repo=... — recent release activity
+      if (request.method === "GET" && path === "/recent-releases") {
+        const since = url.searchParams.get("since") ?? undefined;
+        const limit = url.searchParams.get("limit");
+        const repo = url.searchParams.get("repo") ?? undefined;
+        const items = this.getRecentReleases({
           since,
           limit: limit ? parseInt(limit, 10) : undefined,
           repo,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,18 @@ export interface IssueRecord {
   updatedAt: string;
 }
 
+/** Stored release record in Durable Object SQLite */
+export interface ReleaseRecord {
+  repo: string;
+  tagName: string;
+  name: string;
+  body: string;
+  prerelease: boolean;
+  bodyHash: string;
+  createdAt: string;
+  publishedAt: string;
+}
+
 /** Polling watermark per repository */
 export interface PollWatermark {
   repo: string;
@@ -29,12 +41,14 @@ export interface PollWatermark {
 export interface VectorMetadata {
   repo: string;
   number: number;
-  type: "issue" | "pull_request";
-  state: "open" | "closed";
+  type: "issue" | "pull_request" | "release";
+  state: "open" | "closed" | "published";
   labels: string;
   milestone: string;
   assignees: string;
   updated_at: string;
+  /** Release tag name (releases only) */
+  tag_name?: string;
 }
 
 /** Env bindings for the Worker */


### PR DESCRIPTION
Refs #40

リリース情報（タグ、リリースノート、prerelease）をgithub-rag-mcpの検索・コンテキストツールに追加。
既存のVectorizeインデックスにリリースをembeddingし、MCP toolsから横断的に検索可能にする。

変更概要:
- `ReleaseRecord`型とDO SQLite `releases`テーブル追加
- `pollReleases()`によるETag条件付きリリースポーリング
- `search_issues`にrelease typeフィルタ追加
- `get_issue_context`にissue→リリース紐づけ（close後のリリースを検索）
- `list_recent_activity`にリリースイベント統合
- 要件仕様書を実装に合わせて更新