### PR TITLE
feat: index repository documentation for semantic search

### DIFF
--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -77,6 +77,26 @@ Polling strategy:
 - Separate watermark namespace: `releases:{repo}` in watermarks table
 - Vector ID format: `{repo}#release-{tag_name}` (no collision with `{repo}#{number}`)
 
+### 1c. Documentation Poller
+
+Runs as part of the cron poller, after release polling for each repository.
+
+Responsibilities:
+- Fetch repository documentation files (`docs/**/*.md` + `README.md`) and index for semantic search
+- Detect new, updated, and deleted documentation files
+- Generate embeddings for file content (path as title, content as body)
+- Upsert vectors into Vectorize with doc-specific metadata
+- Store individual file blob SHAs in Durable Object (docs table) for per-file change detection
+- Remove vectors for deleted files
+
+Change detection strategy:
+- Use Git Trees API (`/repos/{owner}/{repo}/git/trees/{ref}?recursive=1`) to get full file list with blob SHAs in 1 request
+- ETag conditional requests on Trees API (304 Not Modified skips all processing)
+- Compare blob SHAs against stored values to detect per-file changes (Git guarantees SHA = content identity)
+- Fetch changed files via Contents API (`/repos/{owner}/{repo}/contents/{path}`, base64-encoded)
+- Separate watermark namespace: `docs:{repo}` in watermarks table
+- Vector ID format: `{repo}#doc-{path}` (e.g., `owner/repo#doc-docs/0-requirements.md`)
+
 ### 2. Embedding Pipeline
 
 Model: `@cf/baai/bge-m3` (Workers AI)
@@ -91,14 +111,15 @@ Embedding triggers:
 
 Vector metadata (stored alongside embedding in Vectorize):
 - `repo` (string) — repository full name (owner/repo)
-- `number` (number) — issue/PR number (0 for releases)
-- `type` (string) — "issue", "pull_request", or "release"
-- `state` (string) — "open" or "closed" (releases: always "published")
-- `labels` (string) — comma-separated label names (releases: empty)
-- `milestone` (string) — milestone title or empty (releases: empty)
-- `assignees` (string) — comma-separated login names (releases: empty)
+- `number` (number) — issue/PR number (0 for releases and docs)
+- `type` (string) — "issue", "pull_request", "release", or "doc"
+- `state` (string) — "open" or "closed" (releases: "published", docs: "active")
+- `labels` (string) — comma-separated label names (releases/docs: empty)
+- `milestone` (string) — milestone title or empty (releases/docs: empty)
+- `assignees` (string) — comma-separated login names (releases/docs: empty)
 - `updated_at` (string) — ISO 8601 timestamp
-- `tag_name` (string) — release tag name (releases only, empty for issues/PRs)
+- `tag_name` (string) — release tag name (releases only, empty for others)
+- `doc_path` (string) — file path relative to repo root (docs only, empty for others)
 
 ### 3. MCP Server
 
@@ -116,12 +137,13 @@ Parameters:
 - `labels` (string[], optional) — filter by label names (AND logic)
 - `milestone` (string, optional) — filter by milestone title
 - `assignee` (string, optional) — filter by assignee login
-- `type` (string, optional) — "issue" | "pull_request" | "release" | "all" (default: "all")
+- `type` (string, optional) — "issue" | "pull_request" | "release" | "doc" | "all" (default: "all")
 - `top_k` (number, optional) — max results (default: 10, max: 50)
 
 Returns:
-- Array of matched issues/PRs/releases with: number, title, state, labels, milestone, assignee, score, url, updated_at
+- Array of matched issues/PRs/releases/docs with: number, title, state, labels, milestone, assignee, score, url, updated_at
 - Releases include: tag_name, prerelease flag
+- Docs include: doc_path
 
 Flow:
 1. Generate embedding for `query` via Workers AI
@@ -162,6 +184,7 @@ Parameters:
 Returns:
 - Array of activity items: type (created/updated/closed), number, title, actor, timestamp, url
 - Includes release activity (type: "release", activity_type: "created")
+- Includes documentation updates (type: "doc", activity_type: "updated")
 
 Flow:
 1. Query Durable Object for issues/PRs with `updated_at >= since`
@@ -189,8 +212,9 @@ GitHub App (same pattern as github-webhook-mcp):
 SQLite-backed structured storage:
 - Issue/PR metadata (number, title, state, labels, milestone, assignees, body hash, timestamps)
 - Release metadata (tag_name, name, prerelease, body hash, timestamps)
-- Polling watermarks (last polled timestamp per repo; releases use `releases:{repo}` key)
-- Used for `get_issue_context`, `list_recent_activity`, and release queries without hitting Vectorize
+- Documentation metadata (path, blob SHA, timestamps) — per-file change detection via blob SHA comparison
+- Polling watermarks (last polled timestamp per repo; releases use `releases:{repo}` key, docs use `docs:{repo}` key)
+- Used for `get_issue_context`, `list_recent_activity`, and release/doc queries without hitting Vectorize
 
 ## Constraints
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -14,7 +14,7 @@
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { Env, IssueRecord, ReleaseRecord, VectorMetadata } from "./types.js";
+import type { Env, IssueRecord, ReleaseRecord, DocRecord, VectorMetadata } from "./types.js";
 import type { GitHubUserProps } from "./oauth.js";
 
 /** User context passed via props from OAuth layer */
@@ -77,7 +77,7 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
     // ── search_issues ──────────────────────────────────────────
     this.server.tool(
       "search_issues",
-      "Semantic search for GitHub issues, PRs, and releases combined with structured filters. " +
+      "Semantic search for GitHub issues, PRs, releases, and repository documentation combined with structured filters. " +
         "Uses embedding similarity (BGE-M3) with optional metadata filters.",
       {
         query: z.string().describe("Natural language search query"),
@@ -103,7 +103,7 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
           .optional()
           .describe("Filter by assignee login"),
         type: z
-          .enum(["issue", "pull_request", "release", "all"])
+          .enum(["issue", "pull_request", "release", "doc", "all"])
           .optional()
           .default("all")
           .describe("Filter by type (default: all)"),
@@ -185,11 +185,14 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
           const number = meta?.number ?? 0;
           const itemType = meta?.type ?? "";
           const tagName = meta?.tag_name ?? "";
+          const docPath = meta?.doc_path ?? "";
 
           // Build URL based on type
           let url: string;
           if (itemType === "release" && tagName) {
             url = `https://github.com/${itemRepo}/releases/tag/${tagName}`;
+          } else if (itemType === "doc" && docPath) {
+            url = `https://github.com/${itemRepo}/blob/main/${docPath}`;
           } else {
             url = `https://github.com/${itemRepo}/issues/${number}`;
           }
@@ -209,10 +212,11 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
             updated_at: meta?.updated_at ?? "",
             repo: itemRepo,
             ...(itemType === "release" ? { tag_name: tagName } : {}),
+            ...(itemType === "doc" ? { doc_path: docPath } : {}),
           };
         });
 
-        // Enrich with titles from IssueStore / release store
+        // Enrich with titles from IssueStore / release store / doc store
         const store = this.getStore();
         for (const item of items) {
           if (item.type === "release" && item.repo && (item as Record<string, unknown>).tag_name) {
@@ -229,6 +233,9 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
             } catch {
               // Best-effort enrichment
             }
+          } else if (item.type === "doc" && item.repo && (item as Record<string, unknown>).doc_path) {
+            // Use the file path as the title for docs
+            item.title = (item as Record<string, unknown>).doc_path as string;
           } else if (item.repo && item.number) {
             try {
               const res = await store.fetch(
@@ -497,7 +504,7 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
     // ── list_recent_activity ───────────────────────────────────
     this.server.tool(
       "list_recent_activity",
-      "List recent issue/PR/release activity across tracked repositories. " +
+      "List recent issue/PR/release/documentation activity across tracked repositories. " +
         "Returns changes classified as created, updated, or closed.",
       {
         repo: z
@@ -592,6 +599,37 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
               url: `https://github.com/${release.repo}/releases/tag/${release.tagName}`,
               updated_at: release.publishedAt,
               created_at: release.createdAt,
+            });
+          }
+        }
+
+        // Fetch recent docs too
+        const docParams = new URLSearchParams();
+        docParams.set("since", effectiveSince);
+        docParams.set("limit", String(effectiveLimit));
+        if (repo) {
+          docParams.set("repo", repo);
+        }
+
+        const docRes = await store.fetch(
+          new Request(`http://store/recent-docs?${docParams.toString()}`),
+        );
+
+        if (docRes.ok) {
+          const docs = (await docRes.json()) as DocRecord[];
+          for (const doc of docs) {
+            activities.push({
+              activity_type: "updated",
+              number: 0,
+              title: doc.path,
+              type: "doc",
+              state: "active",
+              labels: [],
+              repo: doc.repo,
+              doc_path: doc.path,
+              url: `https://github.com/${doc.repo}/blob/main/${doc.path}`,
+              updated_at: doc.updatedAt,
+              created_at: doc.updatedAt,
             });
           }
         }

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -7,7 +7,7 @@
  * Stores structured metadata in IssueStore Durable Object.
  */
 
-import type { Env, IssueRecord, ReleaseRecord } from "./types.js";
+import type { Env, IssueRecord, ReleaseRecord, DocRecord } from "./types.js";
 
 /** GitHub API issue/PR response shape (subset of fields we need) */
 interface GitHubIssue {
@@ -661,6 +661,301 @@ async function pollReleases(
   );
 }
 
+// ── Documentation Polling ────────────────────────────────────────
+
+/** Entry in the Git Trees API response */
+interface GitTreeEntry {
+  path: string;
+  mode: string;
+  type: string;
+  sha: string;
+  size?: number;
+}
+
+/** Git Trees API response shape */
+interface GitTreeResponse {
+  sha: string;
+  tree: GitTreeEntry[];
+  truncated: boolean;
+}
+
+/** Pattern to match target documentation files */
+function isDocFile(path: string): boolean {
+  // Match docs/**/*.md and README.md at root
+  if (path === "README.md") return true;
+  if (path.startsWith("docs/") && path.endsWith(".md")) return true;
+  return false;
+}
+
+/**
+ * Build Vectorize vector ID for a document.
+ * Format: "owner/repo#doc-docs/0-requirements.md"
+ */
+function docVectorId(repo: string, path: string): string {
+  return `${repo}#doc-${path}`;
+}
+
+/**
+ * Fetch the repository tree via Git Trees API with ETag conditional request support.
+ * Returns the tree entries and the response ETag.
+ * When `etag` is provided, sends `If-None-Match` header.
+ * If GitHub responds 304 Not Modified, returns NOT_MODIFIED sentinel.
+ */
+async function fetchRepoTree(
+  repo: string,
+  token: string,
+  ref: string,
+  etag?: string,
+): Promise<{ tree: GitTreeEntry[]; treeSha: string; etag?: string } | typeof NOT_MODIFIED> {
+  const url = `https://api.github.com/repos/${repo}/git/trees/${ref}?recursive=1`;
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "github-rag-mcp/0.1.0",
+  };
+
+  if (etag) {
+    headers["If-None-Match"] = etag;
+  }
+
+  const resp = await fetch(url, {
+    headers,
+    cache: "no-store",
+  } as RequestInit);
+
+  if (resp.status === 304) {
+    return NOT_MODIFIED;
+  }
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`GitHub Trees API error ${resp.status}: ${text}`);
+  }
+
+  const data = (await resp.json()) as GitTreeResponse;
+  const responseEtag = resp.headers.get("etag") ?? undefined;
+  return { tree: data.tree, treeSha: data.sha, etag: responseEtag };
+}
+
+/**
+ * Fetch file content via GitHub Contents API.
+ * Returns the decoded UTF-8 text content.
+ */
+async function fetchFileContent(
+  repo: string,
+  path: string,
+  token: string,
+): Promise<string> {
+  const url = `https://api.github.com/repos/${repo}/contents/${path}`;
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "github-rag-mcp/0.1.0",
+  };
+
+  const resp = await fetch(url, {
+    headers,
+    cache: "no-store",
+  } as RequestInit);
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`GitHub Contents API error ${resp.status} for ${path}: ${text}`);
+  }
+
+  const data = (await resp.json()) as { content: string; encoding: string };
+  if (data.encoding !== "base64") {
+    throw new Error(`Unexpected encoding ${data.encoding} for ${path}`);
+  }
+
+  // Decode base64 content
+  const binary = atob(data.content.replace(/\n/g, ""));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+/**
+ * Poll a single repository for documentation file updates.
+ * Uses Git Trees API for change detection and Contents API for fetching changed files.
+ */
+async function pollDocs(
+  repo: string,
+  env: Env,
+  storeStub: DurableObjectStub,
+): Promise<void> {
+  // Use a separate watermark namespace for docs
+  const watermarkKey = `docs:${repo}`;
+  const wmResp = await storeStub.fetch(
+    new Request(
+      `http://store/watermark?repo=${encodeURIComponent(watermarkKey)}`,
+    ),
+  );
+
+  let storedEtag: string | undefined;
+  if (wmResp.ok) {
+    const wm = (await wmResp.json()) as { repo: string; lastPolledAt: string; etag?: string };
+    storedEtag = wm.etag;
+  }
+
+  console.log(
+    `Polling docs for ${repo}${storedEtag ? " (with ETag)" : ""}`,
+  );
+
+  // Fetch repo tree via Trees API with conditional request
+  const result = await fetchRepoTree(repo, env.GITHUB_TOKEN, "HEAD", storedEtag);
+
+  if (result === NOT_MODIFIED) {
+    console.log(`${repo} docs: 304 Not Modified — no changes`);
+    return;
+  }
+
+  const { tree, etag: responseEtag } = result;
+
+  // Filter to doc files only
+  const docEntries = tree.filter(
+    (entry) => entry.type === "blob" && isDocFile(entry.path),
+  );
+
+  if (docEntries.length === 0) {
+    console.log(`No doc files found in ${repo}`);
+    // Still update watermark with new ETag
+    await storeStub.fetch(
+      new Request("http://store/watermark", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repo: watermarkKey, lastPolledAt: new Date().toISOString(), etag: responseEtag }),
+      }),
+    );
+    return;
+  }
+
+  // Get existing doc records to detect changes via blob SHA comparison
+  const existingDocsResp = await storeStub.fetch(
+    new Request(`http://store/docs?repo=${encodeURIComponent(repo)}`),
+  );
+  const existingDocs: DocRecord[] = existingDocsResp.ok
+    ? (await existingDocsResp.json()) as DocRecord[]
+    : [];
+  const existingDocMap = new Map(existingDocs.map((d) => [d.path, d]));
+
+  // Detect which files changed (blob SHA mismatch) or are new
+  const changedEntries = docEntries.filter((entry) => {
+    const existing = existingDocMap.get(entry.path);
+    return !existing || existing.blobSha !== entry.sha;
+  });
+
+  // Detect deleted files (in store but not in current tree)
+  const currentPaths = new Set(docEntries.map((e) => e.path));
+  const deletedDocs = existingDocs.filter((d) => !currentPaths.has(d.path));
+
+  let embedded = 0;
+  let skipped = docEntries.length - changedEntries.length;
+  let failed = 0;
+  const now = new Date().toISOString();
+
+  // Process changed/new doc files
+  for (const entry of changedEntries) {
+    if (embedded >= MAX_EMBEDDINGS_PER_RUN) {
+      console.warn(
+        `Doc embedding batch limit reached (${MAX_EMBEDDINGS_PER_RUN}). ` +
+        `Remaining docs will be retried next cron run.`,
+      );
+      // Store with empty blobSha so next poll retries
+      break;
+    }
+
+    try {
+      // Fetch file content
+      const content = await fetchFileContent(repo, entry.path, env.GITHUB_TOKEN);
+
+      // Generate embedding (use path as title, content as body)
+      const embeddingInput = prepareEmbeddingInput(entry.path, content);
+      const embedding = await generateEmbedding(env.AI, embeddingInput);
+
+      const metadata: Record<string, string | number> = {
+        repo,
+        number: 0,
+        type: "doc",
+        state: "active",
+        labels: "",
+        milestone: "",
+        assignees: "",
+        updated_at: now,
+        doc_path: entry.path,
+      };
+
+      // Upsert vector into Vectorize
+      await env.VECTORIZE.upsert([
+        {
+          id: docVectorId(repo, entry.path),
+          values: embedding,
+          metadata,
+        },
+      ]);
+
+      // Upsert doc record into store
+      await storeStub.fetch(
+        new Request("http://store/upsert-doc", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            repo,
+            path: entry.path,
+            blobSha: entry.sha,
+            updatedAt: now,
+          }),
+        }),
+      );
+
+      embedded++;
+    } catch (err) {
+      console.error(
+        `Failed to embed doc ${repo}/${entry.path}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+      failed++;
+    }
+  }
+
+  // Handle deleted files: remove from Vectorize and store
+  for (const doc of deletedDocs) {
+    try {
+      await env.VECTORIZE.deleteByIds([docVectorId(repo, doc.path)]);
+      await storeStub.fetch(
+        new Request(
+          `http://store/doc?repo=${encodeURIComponent(repo)}&path=${encodeURIComponent(doc.path)}`,
+          { method: "DELETE" },
+        ),
+      );
+    } catch (err) {
+      console.error(
+        `Failed to delete doc vector ${repo}/${doc.path}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  // Update watermark with ETag
+  await storeStub.fetch(
+    new Request("http://store/watermark", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo: watermarkKey, lastPolledAt: now, etag: responseEtag }),
+    }),
+  );
+
+  console.log(
+    `${repo} docs: ${docEntries.length} found, ${embedded} embedded, ${skipped} unchanged, ${failed} failed, ${deletedDocs.length} deleted`,
+  );
+}
+
 /**
  * Main scheduled handler — called by Cron Trigger every 5 minutes.
  * Polls all configured repositories for issue/PR updates.
@@ -714,6 +1009,15 @@ export async function handleScheduled(
     } catch (err) {
       console.error(
         `Failed to poll releases for ${repo}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    try {
+      await pollDocs(repo, env, storeStub);
+    } catch (err) {
+      console.error(
+        `Failed to poll docs for ${repo}:`,
         err instanceof Error ? err.message : String(err),
       );
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,7 +5,7 @@
  * Body text is NOT stored (only body_hash for embedding change detection).
  */
 
-import type { Env, IssueRecord, ReleaseRecord, PollWatermark } from "./types.js";
+import type { Env, IssueRecord, ReleaseRecord, DocRecord, PollWatermark } from "./types.js";
 
 /** Row shape returned by SQLite for the issues table */
 type IssueRow = {
@@ -34,6 +34,15 @@ type ReleaseRow = {
   body_hash: string;
   created_at: string;
   published_at: string;
+};
+
+/** Row shape returned by SQLite for the docs table */
+type DocRow = {
+  [key: string]: SqlStorageValue;
+  repo: string;
+  path: string;
+  blob_sha: string;
+  updated_at: string;
 };
 
 /** Row shape returned by SQLite for the watermarks table */
@@ -69,6 +78,15 @@ function rowToIssueRecord(row: IssueRow): IssueRecord {
     assignees: row.assignees ? row.assignees.split(",") : [],
     bodyHash: row.body_hash,
     createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToDocRecord(row: DocRow): DocRecord {
+  return {
+    repo: row.repo,
+    path: row.path,
+    blobSha: row.blob_sha,
     updatedAt: row.updated_at,
   };
 }
@@ -134,6 +152,21 @@ export class IssueStore implements DurableObject {
     this.sql.exec(`
       CREATE INDEX IF NOT EXISTS idx_releases_repo
         ON releases (repo, published_at DESC);
+    `);
+
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS docs (
+        repo       TEXT NOT NULL,
+        path       TEXT NOT NULL,
+        blob_sha   TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (repo, path)
+      );
+    `);
+
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS idx_docs_repo
+        ON docs (repo, updated_at DESC);
     `);
 
     // Migration: add etag column if missing (existing deployments)
@@ -321,6 +354,73 @@ export class IssueStore implements DurableObject {
     return [...cursor].map(rowToReleaseRecord);
   }
 
+  // ---- Doc CRUD ----
+
+  upsertDoc(record: DocRecord): void {
+    this.sql.exec(
+      `INSERT INTO docs (repo, path, blob_sha, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT (repo, path) DO UPDATE SET
+         blob_sha   = excluded.blob_sha,
+         updated_at = excluded.updated_at`,
+      record.repo,
+      record.path,
+      record.blobSha,
+      record.updatedAt,
+    );
+  }
+
+  getDoc(repo: string, path: string): DocRecord | null {
+    const cursor = this.sql.exec<DocRow>(
+      `SELECT * FROM docs WHERE repo = ? AND path = ?`,
+      repo,
+      path,
+    );
+    const rows = [...cursor];
+    if (rows.length === 0) return null;
+    return rowToDocRecord(rows[0]);
+  }
+
+  listDocsByRepo(repo: string): DocRecord[] {
+    const cursor = this.sql.exec<DocRow>(
+      `SELECT * FROM docs WHERE repo = ? ORDER BY path ASC`,
+      repo,
+    );
+    return [...cursor].map(rowToDocRecord);
+  }
+
+  getRecentDocs(
+    opts?: { since?: string; limit?: number; repo?: string },
+  ): DocRecord[] {
+    const limit = opts?.limit ?? 20;
+    const since = opts?.since ?? new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+    let query: string;
+    let params: (string | number)[];
+
+    if (opts?.repo) {
+      query = `SELECT * FROM docs WHERE repo = ? AND updated_at >= ? ORDER BY updated_at DESC LIMIT ?`;
+      params = [opts.repo, since, limit];
+    } else {
+      query = `SELECT * FROM docs WHERE updated_at >= ? ORDER BY updated_at DESC LIMIT ?`;
+      params = [since, limit];
+    }
+
+    const cursor = this.sql.exec<DocRow>(query, ...params);
+    return [...cursor].map(rowToDocRecord);
+  }
+
+  /**
+   * Delete a doc record (e.g., when a file is removed from the repo).
+   */
+  deleteDoc(repo: string, path: string): void {
+    this.sql.exec(
+      `DELETE FROM docs WHERE repo = ? AND path = ?`,
+      repo,
+      path,
+    );
+  }
+
   // ---- Hash reset for re-sync ----
 
   /**
@@ -499,6 +599,57 @@ export class IssueStore implements DurableObject {
       if (request.method === "POST" && path === "/watermark") {
         const { repo, lastPolledAt, etag } = (await request.json()) as PollWatermark;
         this.setWatermark(repo, lastPolledAt, etag);
+        return new Response("ok", { status: 200 });
+      }
+
+      // POST /upsert-doc — upsert a single doc record
+      if (request.method === "POST" && path === "/upsert-doc") {
+        const record = (await request.json()) as DocRecord;
+        this.upsertDoc(record);
+        return new Response("ok", { status: 200 });
+      }
+
+      // GET /doc?repo=...&path=... — get a single doc record
+      if (request.method === "GET" && path === "/doc") {
+        const repo = url.searchParams.get("repo");
+        const docPath = url.searchParams.get("path");
+        if (!repo || !docPath) {
+          return new Response("missing repo or path", { status: 400 });
+        }
+        const doc = this.getDoc(repo, docPath);
+        if (!doc) return new Response("not found", { status: 404 });
+        return Response.json(doc);
+      }
+
+      // GET /docs?repo=... — list docs by repo
+      if (request.method === "GET" && path === "/docs") {
+        const repo = url.searchParams.get("repo");
+        if (!repo) return new Response("missing repo", { status: 400 });
+        const docs = this.listDocsByRepo(repo);
+        return Response.json(docs);
+      }
+
+      // GET /recent-docs?since=...&limit=...&repo=... — recent doc activity
+      if (request.method === "GET" && path === "/recent-docs") {
+        const since = url.searchParams.get("since") ?? undefined;
+        const limit = url.searchParams.get("limit");
+        const repo = url.searchParams.get("repo") ?? undefined;
+        const items = this.getRecentDocs({
+          since,
+          limit: limit ? parseInt(limit, 10) : undefined,
+          repo,
+        });
+        return Response.json(items);
+      }
+
+      // DELETE /doc?repo=...&path=... — delete a doc record
+      if (request.method === "DELETE" && path === "/doc") {
+        const repo = url.searchParams.get("repo");
+        const docPath = url.searchParams.get("path");
+        if (!repo || !docPath) {
+          return new Response("missing repo or path", { status: 400 });
+        }
+        this.deleteDoc(repo, docPath);
         return new Response("ok", { status: 200 });
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,14 @@ export interface ReleaseRecord {
   publishedAt: string;
 }
 
+/** Stored document record in Durable Object SQLite */
+export interface DocRecord {
+  repo: string;
+  path: string;
+  blobSha: string;
+  updatedAt: string;
+}
+
 /** Polling watermark per repository */
 export interface PollWatermark {
   repo: string;
@@ -41,14 +49,16 @@ export interface PollWatermark {
 export interface VectorMetadata {
   repo: string;
   number: number;
-  type: "issue" | "pull_request" | "release";
-  state: "open" | "closed" | "published";
+  type: "issue" | "pull_request" | "release" | "doc";
+  state: "open" | "closed" | "published" | "active";
   labels: string;
   milestone: string;
   assignees: string;
   updated_at: string;
   /** Release tag name (releases only) */
   tag_name?: string;
+  /** Document file path (docs only) */
+  doc_path?: string;
 }
 
 /** Env bindings for the Worker */


### PR DESCRIPTION
Refs #41

リポジトリ内ドキュメント（`docs/**/*.md` + `README.md`）をVectorizeにインデックスし、セマンティック検索の対象に加える。Git Trees APIによるツリーSHA比較で変更検出（1 API call/repo）、blob SHA比較でファイル単位の差分検出、ETag条件付きリクエストでアイドル時のAPI呼び出しを最小化。