### PR TITLE
fix(manifest): correct license field to Apache-2.0

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/Liplus-Project/github-rag-mcp",
   "documentation": "https://github.com/Liplus-Project/github-rag-mcp#readme",
   "support": "https://github.com/Liplus-Project/github-rag-mcp/discussions",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "icon": "icon.png",
   "server": {
     "type": "node",


### PR DESCRIPTION
Refs #45

manifest.json の license フィールドを MIT から Apache-2.0 に修正。
リポジトリの実際のライセンス（Apache-2.0）と manifest の記載を一致させる。