### PR TITLE
Add admin reset-hashes route and document Vectorize metadata index prerequisite

### DIFF
--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -191,14 +191,29 @@ Flow:
 2. Sort by updated_at descending
 3. Return with activity type classification
 
-### 4. Authentication
+### 4. Admin API
+
+認証なし公開エンドポイントではなく、`GITHUB_TOKEN` ヘッダーによる認証付き管理用エンドポイント。
+
+#### `POST /admin/reset-hashes?repo=owner/repo`
+
+指定リポジトリの全 issue/PR の bodyHash を空文字にリセットする。
+次回 cron 実行時にハッシュ不一致を検出して全件再 embedding が行われる。
+
+認証: `GITHUB_TOKEN` ヘッダーの値が Worker の `GITHUB_TOKEN` シークレットと一致すること。
+
+用途: Vectorize メタデータインデックス作成後の既存ベクトル再 upsert トリガー。
+
+レスポンス: `{ "repo": "owner/repo", "reset": N }` (N = リセットされた行数)
+
+### 5. Authentication
 
 GitHub App (same pattern as github-webhook-mcp):
 - OAuth 2.1 for user authentication
 - Installation ID for repository access
 - Reference: Liplus-Project/github-webhook-mcp implementation
 
-### 5. Storage
+### 6. Storage
 
 #### Vectorize Index
 
@@ -206,6 +221,25 @@ GitHub App (same pattern as github-webhook-mcp):
 - Dimensions: 1024
 - Metric: cosine
 - Metadata indexes: repo, type, state, labels, milestone, assignees
+
+**前提条件: メタデータインデックスの事前作成が必須**
+
+Vectorize のメタデータフィルタリング（`$eq` など）は、ベクトル挿入前にメタデータインデックスを作成しておく必要がある。
+インデックスなしで upsert されたベクトルはフィルタ対象外となり、構造化フィルタが常に0件を返す。
+
+インデックス作成コマンド（Workers コードからは不可、CLI のみ）:
+
+```sh
+wrangler vectorize create-metadata-index github-rag-issues --type string --property-name repo
+wrangler vectorize create-metadata-index github-rag-issues --type string --property-name type
+wrangler vectorize create-metadata-index github-rag-issues --type string --property-name state
+wrangler vectorize create-metadata-index github-rag-issues --type string --property-name milestone
+```
+
+インデックス作成後、既存ベクトルを再 upsert する必要がある。
+admin エンドポイント（`POST /admin/reset-hashes?repo=owner/repo`、`GITHUB_TOKEN` ヘッダー認証）で bodyHash をリセットすると、次回 cron 実行時に全件が再 embedding される。
+
+参照: https://developers.cloudflare.com/vectorize/reference/metadata-filtering/
 
 #### Durable Object (Issue State Store)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@
  * Routes (defaultHandler, no OAuth token required):
  *   GET /oauth/authorize  -- Start GitHub OAuth flow
  *   GET /oauth/callback   -- GitHub OAuth callback
+ *   POST /admin/reset-hashes?repo=owner/repo  -- Reset bodyHashes to trigger re-embedding (requires GITHUB_TOKEN header)
  *
  * Durable Objects:
  *   RagMcpAgent  -- MCP server (tools: search_issues, get_issue_context, list_recent_activity)
@@ -54,6 +55,37 @@ const mcpHandler = RagMcpAgent.serve("/mcp");
 const innerHandler: ExportedHandler<Env> = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
+
+    // -- Admin: reset body hashes to trigger re-embedding on next cron --
+    // POST /admin/reset-hashes?repo=owner/repo
+    // Requires GITHUB_TOKEN header for authentication.
+    if (request.method === "POST" && url.pathname === "/admin/reset-hashes") {
+      const authHeader = request.headers.get("GITHUB_TOKEN");
+      if (!authHeader || authHeader !== env.GITHUB_TOKEN) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+
+      const repo = url.searchParams.get("repo");
+      if (!repo) {
+        return new Response("missing repo query parameter", { status: 400 });
+      }
+
+      // Proxy to IssueStore Durable Object POST /reset-hashes
+      const storeId = env.ISSUE_STORE.idFromName("global");
+      const storeStub = env.ISSUE_STORE.get(storeId);
+      const storeResp = await storeStub.fetch(
+        new Request(
+          `http://store/reset-hashes?repo=${encodeURIComponent(repo)}`,
+          { method: "POST" },
+        ),
+      );
+
+      const body = await storeResp.text();
+      return new Response(body, {
+        status: storeResp.status,
+        headers: { "Content-Type": storeResp.headers.get("Content-Type") ?? "text/plain" },
+      });
+    }
 
     // -- MCP endpoint (OAuth-protected, ctx.props set by OAuthProvider) --
     if (url.pathname.startsWith("/mcp")) {


### PR DESCRIPTION
Refs #47

Vectorize のメタデータフィルタリングはインデックスを事前作成しないと機能しない。
インデックス作成後に既存ベクトルを再 upsert するための admin エンドポイントを追加し、前提条件をドキュメントに記載する。

## 変更内容

**`src/index.ts`** — `POST /admin/reset-hashes?repo=owner/repo` ルートを追加
- `GITHUB_TOKEN` ヘッダー認証（値が Worker シークレットと一致すること）
- IssueStore DO の既存 `POST /reset-hashes` エンドポイントへのプロキシ
- bodyHash リセット後、次回 cron 実行で全件再 embedding がトリガーされる

**`docs/0-requirements.md`** — 2箇所追加
- 「4. Admin API」セクション: エンドポイント仕様・認証・用途を記載
- Vectorize Index セクション: メタデータインデックス事前作成の必須条件と `wrangler` CLI コマンドを記載