### PR TITLE
fix: reset watermarks and all table hashes on admin reset-hashes (#47)

### DIFF
--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -197,14 +197,29 @@ Flow:
 
 #### `POST /admin/reset-hashes?repo=owner/repo`
 
-指定リポジトリの全 issue/PR の bodyHash を空文字にリセットする。
-次回 cron 実行時にハッシュ不一致を検出して全件再 embedding が行われる。
+指定リポジトリの全データを re-embedding 対象にリセットする。次回 cron 実行時に全件が再取得・再 embedding される。
+
+リセット対象:
+- `issues` テーブルの `body_hash` を空文字にリセット（ポーラーがハッシュ不一致を検出して再 embedding）
+- `releases` テーブルの `body_hash` を空文字にリセット（同上）
+- `docs` テーブルの全行を削除（ポーラーが全ファイルを再取得・再 embedding）
+- `watermarks` テーブルから当該リポジトリの全エントリを削除（issues 用 `{repo}`、releases 用 `releases:{repo}`、docs 用 `docs:{repo}`）
+  - watermark 削除により、ETag / `since` パラメータによるスキップが無効化され、ポーラーが全件を再取得する
 
 認証: `GITHUB_TOKEN` ヘッダーの値が Worker の `GITHUB_TOKEN` シークレットと一致すること。
 
 用途: Vectorize メタデータインデックス作成後の既存ベクトル再 upsert トリガー。
 
-レスポンス: `{ "repo": "owner/repo", "reset": N }` (N = リセットされた行数)
+レスポンス:
+```json
+{
+  "repo": "owner/repo",
+  "issueHashesReset": N,
+  "releaseHashesReset": M,
+  "docsDeleted": K,
+  "watermarksDeleted": W
+}
+```
 
 ### 5. Authentication
 
@@ -237,7 +252,7 @@ wrangler vectorize create-metadata-index github-rag-issues --type string --prope
 ```
 
 インデックス作成後、既存ベクトルを再 upsert する必要がある。
-admin エンドポイント（`POST /admin/reset-hashes?repo=owner/repo`、`GITHUB_TOKEN` ヘッダー認証）で bodyHash をリセットすると、次回 cron 実行時に全件が再 embedding される。
+admin エンドポイント（`POST /admin/reset-hashes?repo=owner/repo`、`GITHUB_TOKEN` ヘッダー認証）で bodyHash・watermark をリセットすると、次回 cron 実行時に全件が再取得・再 embedding される。
 
 参照: https://developers.cloudflare.com/vectorize/reference/metadata-filtering/
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@
  * Routes (defaultHandler, no OAuth token required):
  *   GET /oauth/authorize  -- Start GitHub OAuth flow
  *   GET /oauth/callback   -- GitHub OAuth callback
- *   POST /admin/reset-hashes?repo=owner/repo  -- Reset bodyHashes to trigger re-embedding (requires GITHUB_TOKEN header)
+ *   POST /admin/reset-hashes?repo=owner/repo  -- Reset hashes and watermarks to trigger full re-embedding (requires GITHUB_TOKEN header)
  *
  * Durable Objects:
  *   RagMcpAgent  -- MCP server (tools: search_issues, get_issue_context, list_recent_activity)
@@ -56,8 +56,9 @@ const innerHandler: ExportedHandler<Env> = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
-    // -- Admin: reset body hashes to trigger re-embedding on next cron --
+    // -- Admin: reset hashes and watermarks to trigger full re-embedding on next cron --
     // POST /admin/reset-hashes?repo=owner/repo
+    // Resets: issue body_hash, release body_hash, docs (deleted), and all watermarks for the repo.
     // Requires GITHUB_TOKEN header for authentication.
     if (request.method === "POST" && url.pathname === "/admin/reset-hashes") {
       const authHeader = request.headers.get("GITHUB_TOKEN");

--- a/src/store.ts
+++ b/src/store.ts
@@ -421,19 +421,56 @@ export class IssueStore implements DurableObject {
     );
   }
 
-  // ---- Hash reset for re-sync ----
+  // ---- Full re-embed reset ----
 
   /**
-   * Reset all bodyHashes for a given repo so that the next poll
-   * will regenerate embeddings for every issue.
-   * Returns the number of rows affected.
+   * Reset all state that controls re-embedding so that the next poll
+   * will regenerate embeddings for every issue, release, and doc in the repo.
+   *
+   * Resets:
+   * - body_hash in issues table (cleared to '' so poller detects change)
+   * - body_hash in releases table (cleared to '' so poller detects change)
+   * - blob_sha in docs table (deleted rows so poller re-fetches all files)
+   * - Watermark entries for issues, releases, and docs (deleted so poller
+   *   re-fetches from the beginning, bypassing ETag / since skipping)
+   *
+   * Returns a summary object with counts of what was reset.
    */
-  resetBodyHashes(repo: string): number {
-    const cursor = this.sql.exec(
+  resetForReEmbed(repo: string): {
+    issueHashesReset: number;
+    releaseHashesReset: number;
+    docsDeleted: number;
+    watermarksDeleted: number;
+  } {
+    const issuesCursor = this.sql.exec(
       `UPDATE issues SET body_hash = '' WHERE repo = ? AND body_hash != ''`,
       repo,
     );
-    return cursor.rowsWritten;
+
+    const releasesCursor = this.sql.exec(
+      `UPDATE releases SET body_hash = '' WHERE repo = ? AND body_hash != ''`,
+      repo,
+    );
+
+    const docsCursor = this.sql.exec(
+      `DELETE FROM docs WHERE repo = ?`,
+      repo,
+    );
+
+    // Delete all three watermark namespaces: issues (repo), releases (releases:{repo}), docs (docs:{repo})
+    const watermarksCursor = this.sql.exec(
+      `DELETE FROM watermarks WHERE repo IN (?, ?, ?)`,
+      repo,
+      `releases:${repo}`,
+      `docs:${repo}`,
+    );
+
+    return {
+      issueHashesReset: issuesCursor.rowsWritten,
+      releaseHashesReset: releasesCursor.rowsWritten,
+      docsDeleted: docsCursor.rowsWritten,
+      watermarksDeleted: watermarksCursor.rowsWritten,
+    };
   }
 
   // ---- Watermark management ----
@@ -578,12 +615,12 @@ export class IssueStore implements DurableObject {
         return Response.json(items);
       }
 
-      // POST /reset-hashes?repo=... — reset all bodyHashes for a repo to force re-embedding
+      // POST /reset-hashes?repo=... — reset all hashes and watermarks for a repo to force re-embedding
       if (request.method === "POST" && path === "/reset-hashes") {
         const repo = url.searchParams.get("repo");
         if (!repo) return new Response("missing repo", { status: 400 });
-        const count = this.resetBodyHashes(repo);
-        return Response.json({ repo, reset: count });
+        const summary = this.resetForReEmbed(repo);
+        return Response.json({ repo, ...summary });
       }
 
       // GET /watermark?repo=... — get poll watermark


### PR DESCRIPTION
Refs #47

## 問題

`POST /admin/reset-hashes` が `issues` テーブルの `body_hash` しかリセットしていなかった。
ポーラーは `since` パラメータと ETag による watermark スキップを行うため、watermark を削除しない限り既存の issue/release/doc が再 embedding されない構造バグ。

また releases・docs テーブルのハッシュ/blob_sha もリセット対象外だった。

## 修正内容

- `src/store.ts`: `resetBodyHashes` → `resetForReEmbed` にリネームし、以下を追加
  - `releases` テーブルの `body_hash` を空文字リセット
  - `docs` テーブルの全行削除（blob_sha リセット相当）
  - `watermarks` テーブルから `{repo}`・`releases:{repo}`・`docs:{repo}` の3エントリを削除（ETag/since スキップ無効化）
  - 戻り値を `{ issueHashesReset, releaseHashesReset, docsDeleted, watermarksDeleted }` に変更
- `src/index.ts`: コメント更新（全リセット内容を記載）
- `docs/0-requirements.md`: Admin API セクションのレスポンス仕様・リセット対象を更新