### PR TITLE
Expand doc file detection scope to all .md files

### DIFF
--- a/docs/0-requirements.ja.md
+++ b/docs/0-requirements.ja.md
@@ -96,7 +96,7 @@ Responsibilities:
 - event を embedding pipeline に渡す
 - semantic store と structured store の両方を更新する
 
-`push` は `docs/**/*.md` や `README.md` の変更検出に使う。
+`push` はリポジトリ内の全 `.md` ファイルの変更検出に使う。
 
 ### 3. Cron Poller
 

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -96,7 +96,7 @@ Responsibilities:
 - route events to the embedding pipeline
 - update both semantic and structured stores
 
-`push` is used to detect documentation changes such as `docs/**/*.md` and `README.md`.
+`push` is used to detect changes in all `.md` files across the repository.
 
 ### 3. Cron Poller
 

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -501,12 +501,9 @@ interface GitTreeResponse {
   truncated: boolean;
 }
 
-/** Pattern to match target documentation files */
+/** Pattern to match target documentation files — all .md files in the repository */
 function isDocFile(path: string): boolean {
-  // Match docs/**/*.md and README.md at root
-  if (path === "README.md") return true;
-  if (path.startsWith("docs/") && path.endsWith(".md")) return true;
-  return false;
+  return path.endsWith(".md");
 }
 
 /**

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -114,12 +114,10 @@ function jsonResponse(status: number, body: unknown): Response {
 
 /**
  * Check whether a file path matches the doc file pattern.
- * Matches `docs/**\/*.md` and `README.md` at root — same rule as the poller.
+ * Matches all .md files in the repository.
  */
 function isDocFile(path: string): boolean {
-  if (path === "README.md") return true;
-  if (path.startsWith("docs/") && path.endsWith(".md")) return true;
-  return false;
+  return path.endsWith(".md");
 }
 
 /**


### PR DESCRIPTION
Refs #67

isDocFile()の検出対象をdocs/+READMEのみから全.mdファイルに拡張。
poller.tsとwebhook.tsの両方で同一の変更を適用し、要件定義ドキュメント（EN/JA）のpush検出スコープ記述も更新。