### PR TITLE
fix: add get_doc_content to manifest.json tools array

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -49,6 +49,10 @@
       "description": "Get aggregated context for a single issue/PR including related PRs, branch status, and CI status."
     },
     {
+      "name": "get_doc_content",
+      "description": "Retrieve the content of a document file (.md) from a GitHub repository."
+    },
+    {
       "name": "list_recent_activity",
       "description": "List recent issue/PR activity across tracked repositories."
     }


### PR DESCRIPTION
## Summary
- `mcp-server/manifest.json` の `tools` 配列に `get_doc_content` エントリを追加
- PR #72 で `src/mcp.ts` に実装済みのツールが manifest に反映されていなかったバグを修正

closes #73