### PR TITLE
fix: add get_doc_content tool to mcpb proxy server

### DIFF
--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -9,6 +9,7 @@
  * Tools are proxied to the Worker's MCP endpoint:
  *   search_issues       — semantic + structured search via Vectorize + Workers AI
  *   get_issue_context   — aggregated issue view with related PRs, branch, CI
+ *   get_doc_content     — retrieve .md document content from a repository
  *   list_recent_activity — recent changes across tracked repositories
  */
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -490,6 +491,38 @@ const TOOLS = [
     },
     annotations: {
       title: "Get Issue Context",
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get_doc_content",
+    title: "Get Document Content",
+    description:
+      "Retrieve the content of a document file (.md) from a GitHub repository. " +
+      "Use this to read documents found via search_issues with type: \"doc\". " +
+      "Returns the raw file content fetched from the repository.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repo: {
+          type: "string",
+          description: "Repository (owner/repo)",
+        },
+        path: {
+          type: "string",
+          description:
+            'File path in the repository (e.g. "docs/0-requirements.md")',
+        },
+        ref: {
+          type: "string",
+          description:
+            "Git ref (branch, tag, or commit SHA) to fetch from. Defaults to the repository's default branch.",
+        },
+      },
+      required: ["repo", "path"],
+    },
+    annotations: {
+      title: "Get Document Content",
       readOnlyHint: true,
     },
   },


### PR DESCRIPTION
## purpose

mcpb プロキシサーバー (`mcp-server/server/index.js`) に `get_doc_content` ツール定義を追加し、Worker 側 (`src/mcp.ts`) と整合させる。

## changes

- `TOOLS` 配列に `get_doc_content` のツール定義を追加（`get_issue_context` と `list_recent_activity` の間）
- パラメータ: `repo` (必須), `path` (必須), `ref` (任意) — Worker 側実装と一致
- ファイルヘッダーコメントにツール一覧を追加
- `CallToolRequestSchema` ハンドラーは既に汎用的に `callRemoteTool(name, args)` を呼び出すため、プロキシ処理の変更は不要

## context

PR #72 で Worker 側に `get_doc_content` を実装したが、プロキシサーバーへのツール登録が漏れていた。
#73 (v0.4.3) で manifest.json は4ツールに更新済みだが、実サーバーコードが3ツールのままだったため、Claude Desktop の説明欄(4ツール)と権限欄(3ツール)が不一致になっていた。

Closes #75