### PR TITLE
fix(pipeline): hash vector IDs to stay under Vectorize 64 byte cap

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -106,34 +106,23 @@ export async function generateEmbeddingBatch(
 }
 
 // ── Vector ID builders ───────────────────────────────────────
-
-/**
- * Build Vectorize vector ID from repo and issue number.
- * Format: "owner/repo#123"
- */
-export function vectorId(repo: string, number: number): string {
-  return `${repo}#${number}`;
-}
-
-/**
- * Build Vectorize vector ID for a release.
- * Format: "owner/repo#release-v1.0.0"
- */
-export function releaseVectorId(repo: string, tagName: string): string {
-  return `${repo}#release-${tagName}`;
-}
-
-/**
- * Build Vectorize vector ID for a document.
- * Format: "owner/repo#doc-docs/0-requirements.md"
- */
-export function docVectorId(repo: string, path: string): string {
-  return `${repo}#doc-${path}`;
-}
+//
+// Vectorize enforces a 64-byte cap on vector IDs. The previous scheme embedded
+// the repo name + path/tag/sha as plain text and overflowed for long paths
+// (e.g. `owner/repo#doc-docs/long-filename.md` hit 74 bytes). We now derive a
+// deterministic fixed-length ID by hashing the scheme parts with SHA-256 and
+// encoding as base64url (43 chars). A short type prefix preserves surface
+// separation and keeps the total under 46 bytes, well inside the 64-byte cap.
+//
+// Per-surface prefixes:
+//   "i" — issue / pull request
+//   "d" — doc
+//   "r" — release
+//   "c" — commit diff (file inside a commit)
 
 /**
  * Encode an arbitrary string to URL-safe base64 (RFC 4648 §5) without padding.
- * Used for embedding file paths that contain `/` into Vectorize IDs.
+ * Retained because `stableVectorId` uses it to encode the SHA-256 digest.
  */
 export function base64UrlEncode(input: string): string {
   // Encode UTF-8 -> binary string -> base64 via btoa
@@ -149,15 +138,76 @@ export function base64UrlEncode(input: string): string {
 }
 
 /**
+ * Encode raw bytes as URL-safe base64 (RFC 4648 §5) without padding.
+ * Used to render the SHA-256 digest directly without going through UTF-8.
+ */
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+/**
+ * Build a deterministic fixed-length Vectorize vector ID from a type prefix and
+ * an ordered list of string parts. Parts are joined with a NUL separator (0x00)
+ * so that no legitimate component can forge a collision across surfaces.
+ *
+ * Output format: `{prefix}:{base64url(sha256(part1\0part2\0...))}`
+ * Output length: 1–2 byte prefix + 1 byte separator + 43 byte digest = 45–46 bytes.
+ */
+async function stableVectorId(
+  prefix: string,
+  ...parts: string[]
+): Promise<string> {
+  const input = parts.join("\u0000");
+  const bytes = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", bytes);
+  const digest = base64UrlEncodeBytes(new Uint8Array(hashBuffer));
+  return `${prefix}:${digest}`;
+}
+
+/**
+ * Build Vectorize vector ID from repo and issue number.
+ * Deterministic SHA-256-based ID under the "i" prefix.
+ */
+export function vectorId(repo: string, number: number): Promise<string> {
+  return stableVectorId("i", repo, String(number));
+}
+
+/**
+ * Build Vectorize vector ID for a release.
+ * Deterministic SHA-256-based ID under the "r" prefix.
+ */
+export function releaseVectorId(
+  repo: string,
+  tagName: string,
+): Promise<string> {
+  return stableVectorId("r", repo, tagName);
+}
+
+/**
+ * Build Vectorize vector ID for a document.
+ * Deterministic SHA-256-based ID under the "d" prefix.
+ */
+export function docVectorId(repo: string, path: string): Promise<string> {
+  return stableVectorId("d", repo, path);
+}
+
+/**
  * Build Vectorize vector ID for a commit diff (one file inside one commit).
- * Format: "owner/repo#commit-{sha}#file-{base64url(path)}"
+ * Deterministic SHA-256-based ID under the "c" prefix.
  */
 export function diffVectorId(
   repo: string,
   commitSha: string,
   filePath: string,
-): string {
-  return `${repo}#commit-${commitSha}#file-${base64UrlEncode(filePath)}`;
+): Promise<string> {
+  return stableVectorId("c", repo, commitSha, filePath);
 }
 
 // ── Per-item upsert functions ────────────────────────────────
@@ -282,7 +332,7 @@ export async function processAndUpsertIssue(
     if (metadataChanged) {
       try {
         // Retrieve existing vector values to re-upsert with updated metadata
-        const vid = vectorId(repo, issue.number);
+        const vid = await vectorId(repo, issue.number);
         const vectors = await env.VECTORIZE.getByIds([vid]);
 
         if (vectors.length > 0 && vectors[0].values) {
@@ -356,9 +406,10 @@ export async function processAndUpsertIssue(
       assignee_1: assigneeLogins[1] ?? "",
     };
 
+    const vid = await vectorId(repo, issue.number);
     await env.VECTORIZE.upsert([
       {
-        id: vectorId(repo, issue.number),
+        id: vid,
         values: embedding,
         metadata,
       },
@@ -480,9 +531,10 @@ export async function processAndUpsertRelease(
       tag_name: release.tag_name,
     };
 
+    const rvid = await releaseVectorId(repo, release.tag_name);
     await env.VECTORIZE.upsert([
       {
-        id: releaseVectorId(repo, release.tag_name),
+        id: rvid,
         values: embedding,
         metadata,
       },
@@ -567,9 +619,10 @@ export async function processAndUpsertDoc(
     };
 
     // Upsert vector into Vectorize
+    const dvid = await docVectorId(repo, path);
     await env.VECTORIZE.upsert([
       {
-        id: docVectorId(repo, path),
+        id: dvid,
         values: embedding,
         metadata,
       },
@@ -741,38 +794,42 @@ export async function processAndUpsertCommitDiff(
       continue;
     }
 
-    const vectors = chunk.map((f, i) => {
-      const fileStatus = normaliseFileStatus(f.status);
-      const blobShaAfter = f.sha ?? "";
-      // GitHub's files API does not return the previous blob SHA directly —
-      // we leave it empty for now. blob_sha_after is enough to locate the
-      // post-commit object; history lookup can use the commit SHA itself.
-      const blobShaBefore = "";
+    // Vector IDs are async (SHA-256 digest). Generate them in parallel so the
+    // chunk still maps to a single Vectorize.upsert call below.
+    const vectors = await Promise.all(
+      chunk.map(async (f, i) => {
+        const fileStatus = normaliseFileStatus(f.status);
+        const blobShaAfter = f.sha ?? "";
+        // GitHub's files API does not return the previous blob SHA directly —
+        // we leave it empty for now. blob_sha_after is enough to locate the
+        // post-commit object; history lookup can use the commit SHA itself.
+        const blobShaBefore = "";
 
-      const metadata: Record<string, string | number> = {
-        repo,
-        number: 0,
-        type: "diff",
-        state: "active",
-        labels: "",
-        milestone: "",
-        assignees: "",
-        updated_at: commitDate,
-        commit_sha: commitSha,
-        file_path: f.filename,
-        file_status: fileStatus,
-        commit_date: commitDate,
-        commit_author: commitAuthor,
-        blob_sha_before: blobShaBefore,
-        blob_sha_after: blobShaAfter,
-      };
+        const metadata: Record<string, string | number> = {
+          repo,
+          number: 0,
+          type: "diff",
+          state: "active",
+          labels: "",
+          milestone: "",
+          assignees: "",
+          updated_at: commitDate,
+          commit_sha: commitSha,
+          file_path: f.filename,
+          file_status: fileStatus,
+          commit_date: commitDate,
+          commit_author: commitAuthor,
+          blob_sha_before: blobShaBefore,
+          blob_sha_after: blobShaAfter,
+        };
 
-      return {
-        id: diffVectorId(repo, commitSha, f.filename),
-        values: embeddings[i],
-        metadata,
-      };
-    });
+        return {
+          id: await diffVectorId(repo, commitSha, f.filename),
+          values: embeddings[i],
+          metadata,
+        };
+      }),
+    );
 
     try {
       await env.VECTORIZE.upsert(vectors);

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -705,7 +705,8 @@ async function pollDocs(
   // Handle deleted files: remove from Vectorize and store
   for (const doc of deletedDocs) {
     try {
-      await env.VECTORIZE.deleteByIds([docVectorId(repo, doc.path)]);
+      const dvid = await docVectorId(repo, doc.path);
+      await env.VECTORIZE.deleteByIds([dvid]);
       await storeStub.fetch(
         new Request(
           `http://store/doc?repo=${encodeURIComponent(repo)}&path=${encodeURIComponent(doc.path)}`,

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -219,11 +219,12 @@ async function handleIssueOrPREvent(
 
   // Handle deletion: remove vector and acknowledge
   if (action === "deleted") {
+    const vid = await vectorId(repo, number);
     try {
-      await env.VECTORIZE.deleteByIds([vectorId(repo, number)]);
+      await env.VECTORIZE.deleteByIds([vid]);
     } catch (err) {
       console.error(
-        `Failed to delete vector ${vectorId(repo, number)}:`,
+        `Failed to delete vector ${vid}:`,
         err instanceof Error ? err.message : String(err),
       );
     }
@@ -289,11 +290,12 @@ async function handleReleaseEvent(
 
   // Handle deletion
   if (action === "deleted") {
+    const rvid = await releaseVectorId(repo, tagName);
     try {
-      await env.VECTORIZE.deleteByIds([releaseVectorId(repo, tagName)]);
+      await env.VECTORIZE.deleteByIds([rvid]);
     } catch (err) {
       console.error(
-        `Failed to delete release vector ${releaseVectorId(repo, tagName)}:`,
+        `Failed to delete release vector ${rvid}:`,
         err instanceof Error ? err.message : String(err),
       );
     }
@@ -475,7 +477,8 @@ async function handlePushEvent(
   let deleted = 0;
   for (const path of removed) {
     try {
-      await env.VECTORIZE.deleteByIds([docVectorId(repo, path)]);
+      const dvid = await docVectorId(repo, path);
+      await env.VECTORIZE.deleteByIds([dvid]);
       await storeStub.fetch(
         new Request(
           `http://store/doc?repo=${encodeURIComponent(repo)}&path=${encodeURIComponent(path)}`,


### PR DESCRIPTION
Refs #83

Vectorize の Vector ID 64 byte 上限を超えて `VECTOR_UPSERT_ERROR (code=40008)` で embed が失敗する問題を修正する。doc 長パス (74 byte) と、PR #81 で導入された diff ID scheme (100 byte 以上、原理的に動いていなかった) の両方が対象。

## 変更方針 (issue #83 Option A)

- すべての vector surface の ID を `{prefix}:{base64url(sha256(parts.join("\0")))}` 形式に統一
- prefix は surface 別 (`i` issue/pr, `d` doc, `r` release, `c` diff) の 1 文字 + `:` 区切り
- 出力長は常に 46 byte (2 + 1 + 43) で、64 byte 上限に 18 byte 余裕
- 同じ入力 → 同じ ID の deterministic hash。polling の change-detection には影響なし

## 変更ファイル

- `src/pipeline.ts` — `stableVectorId` 導入、4 surface の ID builder を async 化、`processAndUpsertCommitDiff` の chunk 内 ID 生成を `Promise.all` 化
- `src/webhook.ts` — `deleteByIds` 呼出の await 追従 (issue/release/doc 3 箇所)
- `src/poller.ts` — doc deletion の await 追従

`src/mcp.ts` は search_issues の URL builder が既に metadata (`doc_path` / `file_path` / `commit_sha` / `number`) ベースで組まれており、ID からの reverse-parse は無かったので変更なし。

## 既存 index 互換性

- 本 PR では既存 vector を自動 cleanup しない
- 新 push / 新 poll で新 ID の vector が upsert される → 新旧が Vectorize 内に共存 (古いは参照されなくなるが残る)
- 完全 wipe が必要なら従来どおり `/admin/reset-hashes` 経由で再 embed

## 影響範囲と互換性

- 破壊的変更なし (public API shape 不変、search_issues 結果の URL 構築は metadata ベースのまま)
- TypeScript strict 通過、wrangler dry-run bundle 成功
- docs/ の Vector ID scheme に関する具体記述は無かったため docs 変更なし