### PR TITLE
fix(wrangler): replace placeholder database_id for D1 FTS binding

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -31,7 +31,7 @@ index_name = "github-rag-issues"
 [[d1_databases]]
 binding = "DB_FTS"
 database_name = "github-rag-fts"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"
+database_id = "5e18ffa8-584c-452e-b906-2cf71120c7ad"
 migrations_dir = "migrations"
 
 # Workers AI binding for embedding generation (BGE-M3)


### PR DESCRIPTION
Refs #87

PR #86 で導入した hybrid retrieval 構成の D1 binding について、`wrangler.toml` の `database_id` が placeholder (`REPLACE_WITH_D1_DATABASE_ID`) のまま main に merge されていたため、Cloudflare Workers Builds が build に失敗する状態でした。

本 PR で実際に作成済みの D1 database (`github-rag-fts`, APAC region, ID: `5e18ffa8-584c-452e-b906-2cf71120c7ad`) の ID に差替えます。

## 実施済みの事前作業

- D1 database `github-rag-fts` 作成 (`wrangler d1 create`)
- Migration `0001_fts5_init.sql` を remote に適用 (`wrangler d1 execute --file`, 詳細は commit message)
- `d1_migrations` tracking table にも適用済みとして記録済み

## merge 後の作業

- `wrangler deploy` で本番反映
- `/admin/reset-hashes?repo=…` で既存 Vectorize index の再 embed (hybrid index へ乗せ直し)