### PR TITLE
docs(readme): reflect hybrid retrieval in root README (en/ja)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,7 +9,7 @@ Cloudflare Workers 上で動く、GitHub の issue / pull request / release / do
 [github-webhook-mcp](https://github.com/Liplus-Project/github-webhook-mcp) の検索側カウンターパートとして位置づけています。両者を組み合わせると、AI は次の二つを扱えます。
 
 - いま何が起きたかを push で受け取ること
-- 次に必要な状態を search で引き戻すこと
+- 次に必要な状態を hybrid retrieval (dense + sparse) で引き戻すこと
 
 ## Memory Model
 
@@ -37,16 +37,19 @@ GitHub webhooks + GitHub API
      + webhook receiver
      + cron poller (fallback)
      + embedding pipeline
+     + hybrid retrieval (dense + sparse + RRF fusion)
             |
-            +--> Vectorize (semantic search index)
+            +--> Vectorize (dense semantic index)
+            +--> D1 FTS5 (BM25 sparse index)
             +--> Durable Object / SQLite (structured state store)
             +--> Workers AI BGE-M3 (embeddings)
 ```
 
-- MCP surface は AI クライアント向けの検索・文脈取得ツールを提供します。
+- MCP surface は AI クライアント向けの hybrid retrieval と文脈取得ツールを提供します。
 - webhook receiver は GitHub 更新をほぼリアルタイムで memory に反映します。
 - cron poller は取りこぼし補償と backfill を担います。
-- Vectorize は semantic search index を保持します。
+- Vectorize は dense 側の semantic embedding を保持します。
+- D1 FTS5 は sparse 側の BM25 index を保持し、exact term や識別子クエリを担います。
 - Durable Object は activity と structured lookup のための状態を保持します。
 
 ## Why GitHub
@@ -78,7 +81,7 @@ GitHub webhooks + GitHub API
 
 | Tool | Description |
 |------|-------------|
-| `search_issues` | issue / pull request / release / documentation を semantic search と structured filter で検索する |
+| `search_issues` | issue / pull request / release / documentation を hybrid retrieval (dense + sparse) と structured filter で検索する |
 | `get_issue_context` | 単一 issue / pull request の集約状態を返す。linked PR、branch、CI、sub-issue、related release を含む |
 | `list_recent_activity` | 追跡対象 repository の recent activity を返す。issue、PR、release、documentation 更新を含む |
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GitHub issue, pull request, release, and documentation search for MCP clients on
 It is the search-oriented counterpart to [github-webhook-mcp](https://github.com/Liplus-Project/github-webhook-mcp). Together they provide both:
 
 - push-based awareness of what just happened
-- retrieval of the state that matters for the next step
+- hybrid retrieval (dense + sparse) of the state that matters for the next step
 
 ## Memory Model
 
@@ -37,16 +37,19 @@ GitHub webhooks + GitHub API
      + webhook receiver
      + cron poller (fallback)
      + embedding pipeline
+     + hybrid retrieval (dense + sparse + RRF fusion)
             |
-            +--> Vectorize (semantic search index)
+            +--> Vectorize (dense semantic index)
+            +--> D1 FTS5 (BM25 sparse index)
             +--> Durable Object / SQLite (structured state store)
             +--> Workers AI BGE-M3 (embeddings)
 ```
 
-- The MCP surface exposes semantic search and context tools to AI clients.
+- The MCP surface exposes hybrid retrieval and context tools to AI clients.
 - The webhook receiver updates memory in near real time when GitHub changes.
 - The cron poller repairs missed updates and supports backfill.
-- Vectorize stores semantic embeddings.
+- Vectorize stores semantic embeddings for the dense side of retrieval.
+- D1 FTS5 stores the BM25 sparse index for exact-term and identifier queries.
 - Durable Object keeps structured state for fast lookups and activity views.
 
 ## Why GitHub
@@ -78,7 +81,7 @@ See:
 
 | Tool | Description |
 |------|-------------|
-| `search_issues` | Semantic search across issues, pull requests, releases, and documentation with structured filters. |
+| `search_issues` | Hybrid retrieval (dense + sparse) across issues, pull requests, releases, and documentation with structured filters. |
 | `get_issue_context` | Aggregated state for one issue or pull request, including linked PRs, branch information, CI state, sub-issues, and related releases. |
 | `list_recent_activity` | Recent activity across tracked repositories, including issue, PR, release, and documentation updates. |
 


### PR DESCRIPTION
Refs #89

v0.6.0 で実装された hybrid retrieval (Vectorize dense + D1 FTS5 sparse, RRF fusion) を root の README.md / README.ja.md に追補するマルチランゲージ 2 本同時更新。PR #86 のスコープは docs/ のみで root README が漏れていた分の補完。

## 変更点

- Architecture 図: `Vectorize (dense semantic index)` + `D1 FTS5 (BM25 sparse index)` の 2 行構成へ、上部に `hybrid retrieval (dense + sparse + RRF fusion)` ライン追加
- `search_issues` 説明を `Hybrid retrieval (dense + sparse) + structured filters` に変更
- bullet 説明を dense / sparse 両方に言及する形へ更新

内部仕様 (tokenizer 選択、RRF k=60、migration schema) は docs/0-requirements.{ja,md} に委ね、README には書かない方針。