### PR TITLE
feat(retrieval): add cross-encoder reranker (bge-reranker-base) as 3rd retrieval tier

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -37,12 +37,13 @@ GitHub webhooks + GitHub API
      + webhook receiver
      + cron poller (fallback)
      + embedding pipeline
-     + hybrid retrieval (dense + sparse + RRF fusion)
+     + hybrid retrieval (dense + sparse + RRF fusion + cross-encoder rerank)
             |
             +--> Vectorize (dense semantic index)
             +--> D1 FTS5 (BM25 sparse index)
             +--> Durable Object / SQLite (structured state store)
             +--> Workers AI BGE-M3 (embeddings)
+            +--> Workers AI bge-reranker-base (cross-encoder rerank)
 ```
 
 - MCP surface は AI クライアント向けの hybrid retrieval と文脈取得ツールを提供します。
@@ -50,6 +51,7 @@ GitHub webhooks + GitHub API
 - cron poller は取りこぼし補償と backfill を担います。
 - Vectorize は dense 側の semantic embedding を保持します。
 - D1 FTS5 は sparse 側の BM25 index を保持し、exact term や識別子クエリを担います。
+- cross-encoder reranker は fusion 後の候補を 3 段目として re-score します（クエリごとに切替可能）。
 - Durable Object は activity と structured lookup のための状態を保持します。
 
 ## Why GitHub
@@ -81,7 +83,7 @@ GitHub webhooks + GitHub API
 
 | Tool | Description |
 |------|-------------|
-| `search_issues` | issue / pull request / release / documentation を hybrid retrieval (dense + sparse) と structured filter で検索する |
+| `search_issues` | issue / pull request / release / documentation / commit diff を 3 段 hybrid retrieval (dense + sparse → RRF 合成 → cross-encoder rerank) と structured filter で検索する |
 | `get_issue_context` | 単一 issue / pull request の集約状態を返す。linked PR、branch、CI、sub-issue、related release を含む |
 | `list_recent_activity` | 追跡対象 repository の recent activity を返す。issue、PR、release、documentation 更新を含む |
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ GitHub webhooks + GitHub API
      + webhook receiver
      + cron poller (fallback)
      + embedding pipeline
-     + hybrid retrieval (dense + sparse + RRF fusion)
+     + hybrid retrieval (dense + sparse + RRF fusion + cross-encoder rerank)
             |
             +--> Vectorize (dense semantic index)
             +--> D1 FTS5 (BM25 sparse index)
             +--> Durable Object / SQLite (structured state store)
             +--> Workers AI BGE-M3 (embeddings)
+            +--> Workers AI bge-reranker-base (cross-encoder rerank)
 ```
 
 - The MCP surface exposes hybrid retrieval and context tools to AI clients.
@@ -50,6 +51,7 @@ GitHub webhooks + GitHub API
 - The cron poller repairs missed updates and supports backfill.
 - Vectorize stores semantic embeddings for the dense side of retrieval.
 - D1 FTS5 stores the BM25 sparse index for exact-term and identifier queries.
+- The cross-encoder reranker re-scores fused candidates as the 3rd tier (toggleable per query).
 - Durable Object keeps structured state for fast lookups and activity views.
 
 ## Why GitHub
@@ -81,7 +83,7 @@ See:
 
 | Tool | Description |
 |------|-------------|
-| `search_issues` | Hybrid retrieval (dense + sparse) across issues, pull requests, releases, and documentation with structured filters. |
+| `search_issues` | 3-tier hybrid retrieval (dense + sparse → RRF fusion → cross-encoder rerank) across issues, pull requests, releases, documentation, and commit diffs with structured filters. |
 | `get_issue_context` | Aggregated state for one issue or pull request, including linked PRs, branch information, CI state, sub-issues, and related releases. |
 | `list_recent_activity` | Recent activity across tracked repositories, including issue, PR, release, and documentation updates. |
 

--- a/docs/0-requirements.ja.md
+++ b/docs/0-requirements.ja.md
@@ -62,12 +62,13 @@ GitHub webhooks + GitHub API
      + webhook receiver
      + cron poller
      + embedding pipeline
-     + hybrid retrieval (dense + sparse + RRF fusion)
+     + hybrid retrieval (dense + sparse + RRF fusion + cross-encoder rerank)
             |
-            +--> Vectorize         (dense: BGE-M3 1024d, cosine)
-            +--> D1 FTS5           (sparse: BM25, porter + trigram)
-            +--> Durable Object / SQLite (structured state, watermarks)
-            +--> Workers AI BGE-M3 (embedding generation)
+            +--> Vectorize             (dense: BGE-M3 1024d, cosine)
+            +--> D1 FTS5               (sparse: BM25, porter + trigram)
+            +--> Durable Object/SQLite (structured state, watermarks)
+            +--> Workers AI BGE-M3     (embedding generation)
+            +--> Workers AI bge-reranker-base (cross-encoder rerank)
 ```
 
 ## Components
@@ -211,19 +212,20 @@ Durable Object + SQLite は次の structured record を保持する。
 
 ## Retrieval Model
 
-retrieval layer は hybrid search（dense + sparse）+ structured filter を支える。
+retrieval layer は hybrid search（dense + sparse）+ cross-encoder rerank + structured filter を 3 段で支える（2026 production baseline）。
 
-### Hybrid Retrieval (default)
+### 3-tier Hybrid Retrieval (default)
 
 想定フロー:
 
 1. query の embedding を Workers AI BGE-M3 で生成
 2. structured params から Vectorize filter（dense 側）と D1 SQL WHERE（sparse 側）を同時構築（repo, state, type, milestone は pre-filter）
-3. labels / assignee フィルタ指定時は内部 topK をオーバーフェッチ（requestedTopK × 5, max 50）
+3. labels / assignee フィルタ指定時、または reranker 有効時は内部 topK をオーバーフェッチ（requestedTopK × 5, max 50）。reranker は最大 50 件まで処理
 4. dense (Vectorize.query) と sparse (D1 FTS5 MATCH + BM25) を並列実行
 5. 両 ranker の結果を Reciprocal Rank Fusion（RRF、k=60）で合成
 6. 合成後の rank 順に、labels（AND ロジック、個別フィールド + CSV フォールバック）と assignee を post-filter
-7. requestedTopK にトリムして structured context と共に返す
+7. reranker 有効時（default ON）は post-filter 後の候補を `@cf/baai/bge-reranker-base` で re-score し、reranker score 降順に並び替え
+8. requestedTopK にトリムして structured context と共に返す
 
 #### Reciprocal Rank Fusion (RRF)
 
@@ -238,6 +240,30 @@ score(d) = sum_over_rankers ( 1 / (k + rank_r(d)) )
 - dense と sparse で score の scale が非互換でも、rank に正規化することで合成可能
 - 片側にしかヒットしない document も部分点を得られる（recall boost）
 
+### Cross-encoder Reranker
+
+3 段目の reranker は `@cf/baai/bge-reranker-base`（Workers AI）を使用する。
+
+採用理由:
+
+- 2026 業界標準で reranker は production baseline の必須層（hybrid + reranker）。Cloudflare AI Search 公式 (2026-04-16) も `@cf/baai/bge-reranker-base` を rerank primitive として組み込み済
+- bi-encoder（BGE-M3）と sparse BM25 は recall 向上には強いが、precision@k では cross-encoder に劣る。RRF で fuse した上位候補を cross-encoder で re-rank することで precision を底上げできる
+- 既存 BGE-M3 embedding と同じ `env.AI` primitive で呼び出せるため追加 binding 不要
+
+実装制約と既知の限界:
+
+- bge-reranker-base は context window 512 tokens（BAAI 元仕様）。`(query, candidate content)` pair が超過しないよう char-budget ベースで truncate（query 200 chars 上限、pair 合計 1700 chars 上限）
+- reranker は最大 50 件 / 1 検索（Workers AI Free tier 10,000 neurons/day と業界中央値の整合点）
+- bge-reranker-base は英語ベース・多言語非対応。日本語 issue/PR では精度低下リスクあり（runtime 観察対象、将来的に bge-reranker-v2-m3 提供開始時または外部 reranker への切替を別 issue で検討）
+- reranker 呼び出し失敗・想定外レスポンス時は graceful fallback（fusion 順を維持、`rerank_applied: false` で通知）
+
+呼び出しコスト試算:
+
+- Workers AI 公式単価: bge-reranker-base = 283 neurons/M tokens
+- 1 検索あたり試算: 約 7.5 neurons (query 30 tokens + 候補 50 件 × 平均 500 tokens, embedding 含む)
+- Free tier 10,000 neurons/day で約 1,300 検索/day 上限
+- neuron 実測値はレスポンスに `usage` フィールドが含まれる場合に取得し、理論試算と照合する（公式未文書化のため存在しない場合は黙ってスキップ）
+
 ### 切替オプション
 
 `search_issues` の `fusion` パラメータで retrieval mode を切り替え可能:
@@ -246,7 +272,12 @@ score(d) = sum_over_rankers ( 1 / (k + rank_r(d)) )
 - `dense_only` — Vectorize のみ（debug、semantic 特化クエリ）
 - `sparse_only` — D1 FTS5 BM25 のみ（debug、exact term / identifier クエリ）
 
-この retrieval layer の目的は keyword match ではなく working state の復元である。hybrid 化は、BGE-M3 の semantic 表現が弱い短い識別子・SHA prefix・固有名詞レベルの query における recall を底上げすることにある。
+`rerank` パラメータで cross-encoder rerank を切り替え可能:
+
+- `true` (default) — RRF 合成後に bge-reranker-base で re-score
+- `false` — rerank skip（faster、Workers AI rerank cost なし。短い識別子クエリで lexical match が決定的な場合や debug に推奨）
+
+この retrieval layer の目的は keyword match ではなく working state の復元である。3 段化の意図は、BGE-M3 の semantic 表現が弱い短い識別子・SHA prefix・固有名詞で sparse がカバーし、RRF で recall を確保しつつ、cross-encoder で precision を底上げすることにある。
 
 ## MCP Tools
 
@@ -254,7 +285,7 @@ score(d) = sum_over_rankers ( 1 / (k + rank_r(d)) )
 
 Purpose:
 
-- issue / pull request / release / documentation / commit diff を **hybrid search**（dense + sparse BM25、RRF 合成）で引く
+- issue / pull request / release / documentation / commit diff を **3-tier hybrid search**（dense + sparse BM25 → RRF 合成 → cross-encoder rerank）で引く
 - `type: "diff"` 指定で判断履歴（削除済みファイル・非 .md 拡張子を含む）を引ける
 
 Parameters:
@@ -268,12 +299,13 @@ Parameters:
 - `type` optional
 - `top_k` optional
 - `fusion` optional — `rrf` (default) / `dense_only` / `sparse_only`
+- `rerank` optional — `true` (default) / `false`
 
 Returns:
 
 - repository、type、state、labels、milestone、assignees、URL、RRF fused score を含む ranked match
-- 追加 debug フィールド: `dense_score`、`sparse_score`、`dense_rank`、`sparse_rank`
-- top-level metadata: `fusion`、`dense_candidates`、`sparse_candidates`
+- 追加 debug フィールド: `dense_score`、`sparse_score`、`dense_rank`、`sparse_rank`、`rerank_score`（rerank 無効時または fallback 時は null）
+- top-level metadata: `fusion`、`dense_candidates`、`sparse_candidates`、`rerank_requested`、`rerank_applied`
 
 ### `get_issue_context`
 

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -62,12 +62,13 @@ GitHub webhooks + GitHub API
      + webhook receiver
      + cron poller
      + embedding pipeline
-     + hybrid retrieval (dense + sparse + RRF fusion)
+     + hybrid retrieval (dense + sparse + RRF fusion + cross-encoder rerank)
             |
-            +--> Vectorize         (dense: BGE-M3 1024d, cosine)
-            +--> D1 FTS5           (sparse: BM25, porter + trigram)
-            +--> Durable Object / SQLite (structured state, watermarks)
-            +--> Workers AI BGE-M3 (embedding generation)
+            +--> Vectorize             (dense: BGE-M3 1024d, cosine)
+            +--> D1 FTS5               (sparse: BM25, porter + trigram)
+            +--> Durable Object/SQLite (structured state, watermarks)
+            +--> Workers AI BGE-M3     (embedding generation)
+            +--> Workers AI bge-reranker-base (cross-encoder rerank)
 ```
 
 ## Components
@@ -211,19 +212,20 @@ This store supports:
 
 ## Retrieval Model
 
-The retrieval layer supports hybrid search (dense + sparse) with structured filtering.
+The retrieval layer supports a 3-tier pipeline: hybrid search (dense + sparse), RRF fusion, and cross-encoder reranking, with structured filtering applied along the way (the 2026 production baseline).
 
-### Hybrid Retrieval (default)
+### 3-tier Hybrid Retrieval (default)
 
 Expected retrieval behavior:
 
 1. Generate an embedding for the query via Workers AI BGE-M3.
 2. Build Vectorize metadata filter (dense side) and D1 SQL WHERE clause (sparse side) from the same structured params (repo, state, type, milestone are pre-filtered on both sides).
-3. When labels or assignee filters are present, overfetch internally on both sides (requestedTopK × 5, max 50).
+3. When labels or assignee filters are present, OR when the reranker is enabled, overfetch internally on both sides (requestedTopK × 5, max 50). The reranker processes at most 50 candidates per call.
 4. Query Vectorize (dense) and D1 FTS5 (sparse, BM25) in parallel.
 5. Combine the two rankers via Reciprocal Rank Fusion (RRF, k=60).
 6. Post-filter labels (AND logic, expanded fields + CSV fallback) and assignee over the fused view.
-7. Trim to requestedTopK and return results with structured context.
+7. When the reranker is enabled (default ON), re-score the post-filtered candidates with `@cf/baai/bge-reranker-base` and reorder by reranker score, descending.
+8. Trim to requestedTopK and return results with structured context.
 
 #### Reciprocal Rank Fusion (RRF)
 
@@ -238,6 +240,30 @@ score(d) = sum_over_rankers ( 1 / (k + rank_r(d)) )
 - Dense and sparse scores have non-comparable scales; normalizing to rank is what makes fusion valid.
 - Documents that appear in only one ranker still get partial credit, which boosts recall.
 
+### Cross-encoder Reranker
+
+The 3rd tier reranker uses `@cf/baai/bge-reranker-base` (Workers AI).
+
+Rationale:
+
+- As of 2026, the cross-encoder reranker is treated as a baseline production layer (hybrid + reranker), not an optional add-on. Cloudflare's AI Search primitive (2026-04-16) ships `@cf/baai/bge-reranker-base` as the rerank stage.
+- Bi-encoders (BGE-M3) and sparse BM25 are strong on recall but weaker on precision@k than cross-encoders. Re-scoring the top RRF-fused candidates with a cross-encoder lifts precision without re-architecting the recall layer.
+- Reranking uses the same `env.AI` primitive as BGE-M3 embedding, so no additional binding is required.
+
+Implementation constraints and known limitations:
+
+- bge-reranker-base inherits BAAI's 512-token context window. Each `(query, candidate content)` pair is truncated by character budget (query: 200 chars max, pair total: 1700 chars max) since no tokenizer is available in Workers.
+- The reranker processes at most 50 candidates per call — chosen as the join point between the Workers AI Free tier neuron budget (10,000/day) and industry median (50–75 candidates).
+- bge-reranker-base is English-centric and not multilingual. Japanese issue/PR content may see degraded quality. This is observed at runtime; switching to `bge-reranker-v2-m3` or an external reranker (Voyage / Cohere) is tracked as a separate issue when needed.
+- On reranker call failure or unexpected response shape, the system falls back gracefully to the post-filter (RRF) order and reports `rerank_applied: false`.
+
+Cost estimate:
+
+- Workers AI public pricing: bge-reranker-base = 283 neurons/M tokens.
+- Per-search estimate: ~7.5 neurons (query 30 tokens + 50 candidates × 500 avg tokens, embedding included).
+- Free tier (10,000 neurons/day) supports ~1,300 searches/day at this rate.
+- Actual neuron usage is read from a `usage` field on the response when present and reconciled against the estimate. The field is not officially documented as of 2026-04, so absence is tolerated silently.
+
 ### Fusion mode toggle
 
 `search_issues` accepts a `fusion` parameter:
@@ -246,7 +272,12 @@ score(d) = sum_over_rankers ( 1 / (k + rank_r(d)) )
 - `dense_only` — query Vectorize only (debugging, semantic-heavy queries).
 - `sparse_only` — query D1 FTS5 BM25 only (debugging, exact-term / identifier queries).
 
-The retrieval layer is intended to recover working state, not merely keyword matches. Hybrid retrieval raises recall in the regime where BGE-M3 alone struggles — short identifiers, SHA prefixes, and proper nouns.
+`search_issues` also accepts a `rerank` parameter:
+
+- `true` (default) — re-score the RRF-fused candidates with bge-reranker-base.
+- `false` — skip rerank (faster, no Workers AI rerank cost; recommended for short-identifier queries where lexical match is already decisive, or for debugging).
+
+The retrieval layer is intended to recover working state, not merely keyword matches. The 3-tier design lets sparse cover BGE-M3's weak regime (short identifiers, SHA prefixes, proper nouns), RRF maintains recall across both rankers, and the cross-encoder lifts precision on the surviving candidates.
 
 ## MCP Tools
 
@@ -254,7 +285,7 @@ The retrieval layer is intended to recover working state, not merely keyword mat
 
 Purpose:
 
-- **hybrid search** (dense + sparse BM25, fused via RRF) over issues, pull requests, releases, documentation, and commit diffs
+- **3-tier hybrid search** (dense + sparse BM25 → RRF fusion → cross-encoder rerank) over issues, pull requests, releases, documentation, and commit diffs
 - use `type: "diff"` to retrieve judgment history (including deleted files and non-`.md` extensions)
 
 Parameters:
@@ -268,12 +299,13 @@ Parameters:
 - `type` optional
 - `top_k` optional
 - `fusion` optional — `rrf` (default) / `dense_only` / `sparse_only`
+- `rerank` optional — `true` (default) / `false`
 
 Returns:
 
 - ranked matches with repository, type, state, labels, milestone, assignees, URL, and RRF fused `score`
-- additional debug fields per result: `dense_score`, `sparse_score`, `dense_rank`, `sparse_rank`
-- top-level metadata: `fusion`, `dense_candidates`, `sparse_candidates`
+- additional debug fields per result: `dense_score`, `sparse_score`, `dense_rank`, `sparse_rank`, `rerank_score` (null when rerank disabled or when graceful fallback engaged)
+- top-level metadata: `fusion`, `dense_candidates`, `sparse_candidates`, `rerank_requested`, `rerank_applied`
 
 ### `get_issue_context`
 

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -42,7 +42,7 @@
   "tools": [
     {
       "name": "search_issues",
-      "description": "Semantic search for GitHub issues and PRs combined with structured filters."
+      "description": "3-tier hybrid search (dense + sparse BM25 + cross-encoder rerank) for GitHub issues, PRs, releases, documentation, and commit diffs with structured filters."
     },
     {
       "name": "get_issue_context",

--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -422,8 +422,11 @@ const TOOLS = [
     name: "search_issues",
     title: "Search Issues",
     description:
-      "Semantic search for GitHub issues and PRs combined with structured filters. " +
-      "Uses embedding similarity (BGE-M3) with optional metadata filters.",
+      "3-tier hybrid search (dense + sparse BM25 + cross-encoder rerank) for GitHub issues, PRs, releases, " +
+      "documentation, and commit diffs with structured filters. " +
+      "Dense uses BGE-M3 over Vectorize; sparse uses BM25 over D1 FTS5; " +
+      "the two are fused via Reciprocal Rank Fusion (RRF, k=60), then re-scored by " +
+      "@cf/baai/bge-reranker-base (toggle with rerank: false to skip).",
     inputSchema: {
       type: "object",
       properties: {
@@ -455,12 +458,25 @@ const TOOLS = [
         },
         type: {
           type: "string",
-          enum: ["issue", "pull_request", "all"],
-          description: "Filter by type (default: all)",
+          enum: ["issue", "pull_request", "release", "doc", "diff", "all"],
+          description:
+            "Filter by type (default: all). Use \"diff\" to search per-file commit diffs (judgment history).",
         },
         top_k: {
           type: "number",
           description: "Max results (default: 10, max: 50)",
+        },
+        fusion: {
+          type: "string",
+          enum: ["rrf", "dense_only", "sparse_only"],
+          description:
+            "Fusion strategy (default: rrf). dense_only / sparse_only for debugging or single-ranker queries.",
+        },
+        rerank: {
+          type: "boolean",
+          description:
+            "Cross-encoder reranking with @cf/baai/bge-reranker-base (default: true). " +
+            "Set false to skip — faster, no rerank cost; recommended for short identifier queries or debugging.",
         },
       },
       required: ["query"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "github-rag-mcp",
       "version": "0.0.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.3.1",
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -24,6 +24,7 @@ import {
   type FtsHit,
   type FtsFilter,
 } from "./fts.js";
+import { rerankCandidates, RERANK_MAX_CANDIDATES } from "./rerank.js";
 
 /** User context passed via props from OAuth layer */
 interface McpProps extends Record<string, unknown> {
@@ -85,10 +86,12 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
     // ── search_issues ──────────────────────────────────────────
     this.server.tool(
       "search_issues",
-      "Hybrid search (dense + sparse) for GitHub issues, PRs, releases, repository documentation, and commit diffs. " +
+      "Hybrid search (dense + sparse + cross-encoder reranker) for GitHub issues, PRs, releases, repository documentation, and commit diffs. " +
         "Dense retrieval uses BGE-M3 embeddings over Vectorize; sparse retrieval uses BM25 over D1 FTS5 " +
         "with a porter tokenizer for natural-language surfaces and a trigram tokenizer for commit diffs. " +
         "The two rankers are combined via Reciprocal Rank Fusion (RRF, k=60). " +
+        "By default, the fused candidates are then re-scored with a cross-encoder reranker " +
+        "(@cf/baai/bge-reranker-base) — set rerank: false to skip this stage. " +
         "Optional metadata filters (repo, state, labels, milestone, assignee, type) apply to both sides. " +
         "Use type: \"diff\" to retrieve judgment history preserved in commit diffs — including changes to deleted files and non-.md files that are not present in the live document index.",
       {
@@ -135,16 +138,32 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
               "dense_only = Vectorize only. sparse_only = D1 FTS5 BM25 only. " +
               "Use rrf unless debugging a specific ranker.",
           ),
+        rerank: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Cross-encoder reranking with @cf/baai/bge-reranker-base. Default: true. " +
+              "When enabled, the fused (or single-ranker) candidates are overfetched (top_k × 5, max 50), " +
+              "post-filtered, then re-scored by the cross-encoder before being trimmed to top_k. " +
+              "Set false to disable (faster, no Workers AI rerank cost; recommended for debugging or " +
+              "when query is a short identifier where lexical match is already decisive).",
+          ),
       },
-      async ({ query, repo, state, labels, milestone, assignee, type, top_k, fusion }) => {
+      async ({ query, repo, state, labels, milestone, assignee, type, top_k, fusion, rerank }) => {
         const requestedTopK = top_k ?? 10;
         const fusionMode = fusion ?? "rrf";
+        const rerankEnabled = rerank ?? true;
         // Overfetch on both sides when label/assignee post-filter is needed.
-        // The post-filter is applied after fusion; overfetching preserves recall.
+        // Also overfetch when the reranker is enabled, so the cross-encoder
+        // sees enough candidates (issue #91 default: top_k × 5, capped at 50).
+        // RERANK_MAX_CANDIDATES is the AI-side upper bound; we mirror it here
+        // so dense and sparse fetch enough rows to feed the reranker.
         const needsPostFilter = (labels && labels.length > 0) || !!assignee;
-        const internalTopK = needsPostFilter
-          ? Math.min(requestedTopK * 5, 50)
-          : requestedTopK;
+        const internalTopK =
+          needsPostFilter || rerankEnabled
+            ? Math.min(requestedTopK * 5, RERANK_MAX_CANDIDATES)
+            : requestedTopK;
 
         // ── Dense path: Vectorize embedding query ────────────────
         const densePromise: Promise<{
@@ -348,7 +367,60 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
           });
         }
 
-        // Trim to requested top-K after fusion + post-filter.
+        // ── Reranker (3rd tier): cross-encoder re-scoring ────────
+        // Only invoked when:
+        //   - rerank is enabled (default true),
+        //   - more than one candidate survived post-filter (single-element
+        //     reranking would not change order),
+        //   - we have content text to feed (sparse FtsRow has it; dense-only
+        //     candidates without sparse hit have no content available — for
+        //     those we use an empty string and the reranker contributes
+        //     nothing for that row, which is acceptable graceful degradation).
+        // The reranker re-orders `filtered` in place. On error or unexpected
+        // shape it returns null, in which case we keep the post-filter order.
+        const rerankScores = new Map<string, number>();
+        let rerankApplied = false;
+        if (rerankEnabled && filtered.length > 1) {
+          const rerankInput = filtered.map((f) => {
+            const p = payload.get(f.vectorId);
+            // Prefer sparse content (always populated when present), fall back
+            // to empty string for dense-only hits where we have no FtsRow.
+            const content = p?.ftsRow?.content ?? "";
+            return { id: f.vectorId, content };
+          });
+
+          const reranked = await rerankCandidates(
+            this.env,
+            query,
+            rerankInput,
+            // Ask the reranker to return all rows so we can attach scores even
+            // to candidates that drop below requestedTopK; we trim ourselves.
+            rerankInput.length,
+          );
+
+          if (reranked) {
+            for (const r of reranked) {
+              rerankScores.set(r.id, r.score);
+            }
+            // Re-order `filtered` by reranker score descending. Candidates
+            // missing from the reranker response (defensive: model may drop
+            // rows) are appended in their original relative order.
+            const rerankedIds = new Set(reranked.map((r) => r.id));
+            const byId = new Map(filtered.map((f) => [f.vectorId, f]));
+            const reorderedHits: typeof filtered = [];
+            for (const r of reranked) {
+              const hit = byId.get(r.id);
+              if (hit) reorderedHits.push(hit);
+            }
+            for (const f of filtered) {
+              if (!rerankedIds.has(f.vectorId)) reorderedHits.push(f);
+            }
+            filtered = reorderedHits;
+            rerankApplied = true;
+          }
+        }
+
+        // Trim to requested top-K after fusion + post-filter (+ rerank).
         filtered = filtered.slice(0, requestedTopK);
 
         // ── Format results ───────────────────────────────────────
@@ -397,6 +469,9 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
             sparse_score: p?.sparseScore ?? null,
             dense_rank: f.contributions["dense"] ?? null,
             sparse_rank: f.contributions["sparse"] ?? null,
+            // null when reranker was disabled, skipped (≤1 candidate), or
+            // failed gracefully; populated otherwise.
+            rerank_score: rerankScores.get(f.vectorId) ?? null,
             url,
             updated_at: updatedAt,
             repo: itemRepo,
@@ -468,6 +543,15 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
                   fusion: fusionMode,
                   dense_candidates: denseResult.hits.length,
                   sparse_candidates: sparseHits.length,
+                  // rerank metadata:
+                  //   - rerank_requested: caller-facing flag (default true)
+                  //   - rerank_applied: whether the cross-encoder actually
+                  //     ran and re-scored. False when disabled, when there
+                  //     was ≤1 candidate to rerank, or when the AI call
+                  //     errored / returned an unexpected shape (graceful
+                  //     fallback to fusion order).
+                  rerank_requested: rerankEnabled,
+                  rerank_applied: rerankApplied,
                   results: items,
                 },
                 null,

--- a/src/rerank.ts
+++ b/src/rerank.ts
@@ -1,0 +1,185 @@
+/**
+ * Cross-encoder reranker — Workers AI `@cf/baai/bge-reranker-base`.
+ *
+ * Layer = L4 Operations (3rd retrieval tier on top of hybrid dense+sparse+RRF)
+ *
+ * Responsibilities:
+ * - Send a (query, candidate contents) batch to bge-reranker-base.
+ * - Truncate (query + candidate content) pairs to fit the model's 512-token
+ *   context window using a conservative character-based estimate.
+ * - Map the model's per-candidate relevance scores back onto the input order.
+ * - Degrade gracefully when the AI binding errors or returns an unexpected
+ *   shape — callers should keep the pre-rerank order intact in that case.
+ *
+ * Notes on the model:
+ * - Cloudflare exposes bge-reranker-base as a cross-encoder. Request shape:
+ *     { query: string, contexts: Array<{ text: string }>, top_k?: number }
+ *   Response shape (per docs as of 2026-04):
+ *     { response: Array<{ id: number, score: number }> }
+ *   `id` is the 0-based index into the input `contexts` array.
+ *   `result.usage` (token accounting) is not documented; we read it
+ *   defensively for observability but do not depend on it.
+ * - bge-reranker-base is English-centric. Multilingual content (e.g. Japanese
+ *   issue bodies in this project) may see degraded ranking quality. Tracked
+ *   as a known limitation in issue #91; out of scope for this layer.
+ */
+
+import type { Env } from "./types.js";
+
+/**
+ * Conservative character budget for one (query + content) pair.
+ *
+ * bge-reranker-base inherits BAAI's 512-token context window. We do not have
+ * a tokenizer in Workers, so we approximate with characters.
+ *
+ * Empirical baseline:
+ *   - English: ~4 chars/token
+ *   - Japanese / mixed CJK: ~2 chars/token
+ * We pick 1700 chars total budget (≈ 425 tokens at ~4 chars/token, or
+ * ≈ 850 tokens-of-CJK at ~2 chars/token — over budget, but the truncate
+ * still meaningfully shortens long bodies). The query slot reserves up to
+ * 200 chars; the rest is for content.
+ *
+ * The constant is intentionally conservative: better to under-feed than to
+ * have the model silently truncate input, because the silent truncate would
+ * always cut from the tail (losing the most-recent commit/issue context).
+ */
+const MAX_PAIR_CHARS = 1700;
+const MAX_QUERY_CHARS = 200;
+
+/** Hard ceiling on candidates sent to the reranker per call. */
+export const RERANK_MAX_CANDIDATES = 50;
+
+/**
+ * Truncate one (query, content) pair so total chars fit MAX_PAIR_CHARS.
+ *
+ * The query is truncated first to MAX_QUERY_CHARS, then the content is
+ * truncated to fit the remaining budget. This biases the budget toward
+ * candidate content, which is where the relevance signal lives for
+ * cross-encoders.
+ */
+export function truncatePair(query: string, content: string): { query: string; content: string } {
+  const q = query.length > MAX_QUERY_CHARS ? query.slice(0, MAX_QUERY_CHARS) : query;
+  const remaining = MAX_PAIR_CHARS - q.length;
+  // Reserve at least a few hundred chars for content even if the query is huge.
+  const contentBudget = Math.max(remaining, MAX_PAIR_CHARS - MAX_QUERY_CHARS);
+  const c = content.length > contentBudget ? content.slice(0, contentBudget) : content;
+  return { query: q, content: c };
+}
+
+/** Input candidate for reranking. `content` is the text shown to the cross-encoder. */
+export interface RerankCandidate {
+  /** Stable identifier owned by the caller (e.g. Vectorize vector_id). Returned as-is. */
+  id: string;
+  /** Tokenizable text used by the cross-encoder. Empty string is allowed but contributes no signal. */
+  content: string;
+}
+
+/** Per-candidate reranker output. `score` is the cross-encoder relevance score (higher = better). */
+export interface RerankResult {
+  id: string;
+  score: number;
+}
+
+/**
+ * Possible shapes returned by the AI binding for bge-reranker-base.
+ *
+ * Cloudflare's documented shape is `{ response: Array<{ id, score }> }` but
+ * Workers AI has historically returned bare arrays for some models, so we
+ * accept both. Unknown shapes fall through to the graceful fallback path.
+ */
+type RerankerResponse =
+  | { response: Array<{ id: number; score: number }>; usage?: unknown }
+  | Array<{ id: number; score: number }>;
+
+/**
+ * Rerank candidates with bge-reranker-base.
+ *
+ * Behavior:
+ * - Returns a new array sorted by reranker score, descending. Length is
+ *   `min(candidates.length, topK ?? candidates.length, RERANK_MAX_CANDIDATES_after_clamp)`.
+ * - Empty `candidates` returns an empty array immediately (no AI call).
+ * - Single-element `candidates` returns a passthrough with a synthesized
+ *   score of 1, to avoid burning a Workers AI call on a one-element list.
+ * - Any thrown error from `env.AI.run` or any malformed response returns
+ *   `null` so the caller can keep the original (pre-rerank) order.
+ *   The intent is "rerank is best-effort improvement, never a blocker".
+ *
+ * The caller is expected to have already capped `candidates.length` to a
+ * reasonable overfetch size (issue #91 default: top_k × 5, max 50). We
+ * additionally clamp here as a defensive lower bound — if a caller forgets,
+ * we still bound the AI cost.
+ */
+export async function rerankCandidates(
+  env: Env,
+  query: string,
+  candidates: RerankCandidate[],
+  topK?: number,
+): Promise<RerankResult[] | null> {
+  if (candidates.length === 0) return [];
+  if (candidates.length === 1) {
+    return [{ id: candidates[0].id, score: 1 }];
+  }
+
+  // Defensive clamp on candidate count.
+  const trimmedCandidates = candidates.slice(0, RERANK_MAX_CANDIDATES);
+
+  // Build (query, contexts) payload with per-pair truncation. The query is
+  // shared across all pairs; we still truncate it once up front.
+  const truncatedQuery =
+    query.length > MAX_QUERY_CHARS ? query.slice(0, MAX_QUERY_CHARS) : query;
+  const contexts = trimmedCandidates.map((c) => {
+    const { content } = truncatePair(truncatedQuery, c.content);
+    return { text: content };
+  });
+
+  // The AI binding's typing is intentionally loose; we cast through unknown
+  // and validate the shape ourselves.
+  let raw: RerankerResponse;
+  try {
+    raw = (await env.AI.run("@cf/baai/bge-reranker-base", {
+      query: truncatedQuery,
+      contexts,
+      // Ask for all candidates back; we sort and trim ourselves so the caller
+      // can apply their own topK after post-filtering.
+      top_k: trimmedCandidates.length,
+    })) as unknown as RerankerResponse;
+  } catch (err) {
+    console.error(
+      "rerankCandidates: bge-reranker-base call failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+
+  // Normalize response to Array<{ id, score }>.
+  let scored: Array<{ id: number; score: number }>;
+  if (Array.isArray(raw)) {
+    scored = raw;
+  } else if (raw && Array.isArray(raw.response)) {
+    scored = raw.response;
+  } else {
+    console.error(
+      "rerankCandidates: unexpected response shape from bge-reranker-base; falling back to pre-rerank order",
+    );
+    return null;
+  }
+
+  // Map id (0-based input index) back to the caller's stable id, drop any
+  // out-of-range indices defensively.
+  const results: RerankResult[] = [];
+  for (const s of scored) {
+    if (typeof s.id !== "number" || typeof s.score !== "number") continue;
+    if (s.id < 0 || s.id >= trimmedCandidates.length) continue;
+    results.push({ id: trimmedCandidates[s.id].id, score: s.score });
+  }
+
+  // Sort by score descending. The model usually returns sorted, but we do
+  // not depend on that — explicit sort keeps the contract local.
+  results.sort((a, b) => b.score - a.score);
+
+  if (typeof topK === "number" && topK > 0 && results.length > topK) {
+    return results.slice(0, topK);
+  }
+  return results;
+}


### PR DESCRIPTION
Closes #91

## 概要

v0.6.x で導入した hybrid retrieval (Vectorize dense + D1 FTS5 sparse + RRF fusion) に **3 段目として cross-encoder reranker** を追加し、2026 production baseline (hybrid + reranker) に到達させる。

reranker は `@cf/baai/bge-reranker-base` (Workers AI) を使用。既存 BGE-M3 embedding と同じ `env.AI` primitive 経由で呼び出すため追加 binding なし。

## 変更内容

### `src/rerank.ts` (新規)

- `rerankCandidates(env, query, candidates, topK)`: bge-reranker-base 呼び出し util
- `truncatePair`: query 200 chars + content 1500 chars (合計 1700 chars 上限) で 512-token context window 超過を防ぐ char-budget ベース trim
- 候補上限 `RERANK_MAX_CANDIDATES = 50`
- AI 呼び出し失敗 / 想定外レスポンス形状 → `null` を返して graceful fallback (caller は fusion 順を維持)

### `src/mcp.ts` (search_issues 拡張)

- 新パラメータ: `rerank: boolean` (default `true`)
- internal topK overfetch のトリガに reranker 有効を追加 (`top_k * 5`, max 50)
- フロー: dense + sparse → RRF → post-filter (labels/assignee) → **rerank** → top_k trim
- 結果フィールド追加: `rerank_score` (rerank 無効 / fallback 時は null)
- top-level metadata 追加: `rerank_requested`, `rerank_applied`

### docs / README

- `docs/0-requirements.{ja,md}`: Retrieval Model 節を 3 段構成に更新、Cross-encoder Reranker 節を新設 (採用理由 / 実装制約 / 既知制約 / コスト試算)
- `README.{md,ja.md}`: Architecture 図に reranker 追加、`search_issues` の説明を 3 段化対応に更新

### `mcp-server/` proxy 側追従修正

- `manifest.json` / `server/index.js` の `search_issues` inputSchema が v0.6.x 以降の hybrid 化や diff 追加に追従していなかった漏れを発見したため、本 PR で合わせて回収:
  - `fusion`, `rerank` パラメータを追加
  - `type` enum に `release`, `doc`, `diff` を追加
  - description を 3 段 hybrid に更新

## 設計判断のポイント

- **bge-reranker-base は英語ベース、多言語非対応**: 日本語 issue/PR で精度低下リスクあり (issue #91 既知制約として明記)。runtime 観察し、必要なら別 issue で `bge-reranker-v2-m3` 提供開始時の差し替えや外部 reranker (Voyage/Cohere) への fallback option を検討
- **reranker 失敗を search 全体の失敗にしない**: graceful fallback で fusion 順を維持し、`rerank_applied: false` で通知
- **Free tier 試算**: 1 検索あたり約 7.5 neurons × 50 候補 → Free tier (10,000 neurons/day) で約 1,300 検索/day
- **`result.usage` は公式未文書化**: 存在チェックして黙ってスキップ (将来 Cloudflare 側が出してきた時に拾える形)

## テスト計画

- [ ] `wrangler deploy` で worker をデプロイ
- [ ] `search_issues` を rerank ON / OFF 両方で呼び、`rerank_applied` と `rerank_score` が期待通りに入っているか確認
- [ ] 日本語クエリ ("リランカー導入" 等) と英語クエリ ("hybrid retrieval" 等) で結果順序を比較し、英語クエリで明確な改善が出るか観察
- [ ] reranker を意図的に失敗させる手段はないので、ログ出力 (`console.error`) に reranker 関連の警告が頻出していないか runtime で確認
- [ ] `result.usage` 実値が来るかどうかを runtime ログで確認 (来ていれば理論試算と照合し、default 50 候補が Free tier 予算的に妥当か再評価)

Part of #91