### PR TITLE
diag(mcp): add get_doc_content auth-path logging (patch)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -36,8 +36,27 @@ interface McpProps extends Record<string, unknown> {
 const GITHUB_API = "https://api.github.com";
 const USER_AGENT = "github-rag-mcp/0.1.0";
 
+/**
+ * Diagnostic summary of an access token — never includes the token body.
+ * Surfaces only: length, first 4 chars (GitHub token prefix e.g. "ghu_" / "gho_" / "ghp_"),
+ * and a trailing "…" marker so readers know it is truncated.
+ * Used by logs that need to correlate 401 failures with the token's shape.
+ */
+function describeToken(token: string | undefined | null): string {
+  if (!token) {
+    return "<missing>";
+  }
+  const prefix = token.slice(0, 4);
+  return `len=${token.length} prefix=${prefix}…`;
+}
+
 /** Build GitHub API request headers using the authenticated user's token */
 function githubHeaders(token: string): Record<string, string> {
+  // Diagnostic (issue #98): log token shape on every header build so we can
+  // correlate 401 failures with the token surface. No token body is emitted.
+  console.log(
+    `githubHeaders: building Authorization header token=${describeToken(token)}`,
+  );
   return {
     Authorization: `Bearer ${token}`,
     Accept: "application/vnd.github+json",
@@ -75,7 +94,21 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
 
   /** Get the authenticated user's GitHub access token from props */
   private getGitHubToken(): string {
+    // Diagnostic (issue #98): log props propagation state. 401s may stem from
+    // props not reaching the DO, a missing accessToken field, or a stale token.
+    // Only token shape is surfaced — never the token body.
+    const propsPresent = this.props !== undefined && this.props !== null;
+    const propKeys = propsPresent
+      ? Object.keys(this.props as Record<string, unknown>).join(",")
+      : "<no-props>";
     const token = this.props?.accessToken;
+    console.log(
+      `getGitHubToken: props=${propsPresent ? "present" : "missing"} ` +
+        `propKeys=[${propKeys}] ` +
+        `githubUserId=${this.props?.githubUserId ?? "<missing>"} ` +
+        `githubLogin=${this.props?.githubLogin ?? "<missing>"} ` +
+        `token=${describeToken(token)}`,
+    );
     if (!token) {
       throw new Error("No GitHub access token available");
     }
@@ -832,6 +865,13 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
           ),
       },
       async ({ repo, path, ref }) => {
+        // Diagnostic (issue #98): entry log to confirm handler invocation and
+        // parameter shape. Helps distinguish "handler never ran" from
+        // "handler ran but token missing".
+        console.log(
+          `get_doc_content: entry repo=${repo} path=${path} ref=${ref ?? "<default>"}`,
+        );
+
         const token = this.getGitHubToken();
         const headers = githubHeaders(token);
 
@@ -862,8 +902,29 @@ export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
 
         if (!response.ok) {
           const body = await response.text().catch(() => "");
+          // Diagnostic (issue #98): surface auth-relevant response headers on
+          // failure so we can distinguish scope issues (X-OAuth-Scopes),
+          // auth-challenge details (www-authenticate), and rate-limit state.
+          // These headers do not contain the token body.
+          const diagHeaders = {
+            "x-oauth-scopes": response.headers.get("x-oauth-scopes"),
+            "x-accepted-oauth-scopes": response.headers.get(
+              "x-accepted-oauth-scopes",
+            ),
+            "www-authenticate": response.headers.get("www-authenticate"),
+            "x-github-request-id": response.headers.get("x-github-request-id"),
+            "x-ratelimit-remaining": response.headers.get(
+              "x-ratelimit-remaining",
+            ),
+            "x-ratelimit-resource": response.headers.get(
+              "x-ratelimit-resource",
+            ),
+          };
           console.error(
-            `get_doc_content: GitHub API returned ${response.status} for ${repo}/${path}: ${body}`,
+            `get_doc_content: GitHub API returned ${response.status} for ${repo}/${path}: ` +
+              `token=${describeToken(token)} ` +
+              `headers=${JSON.stringify(diagHeaders)} ` +
+              `body=${body}`,
           );
           return {
             content: [


### PR DESCRIPTION
## 概要

#98 で観測された `get_doc_content` HTTP 401 の真因切り分け用に、`src/mcp.ts` の認証パスへ診断ログを追加する。成功系を含め挙動は変えない。再観測は deploy 後に別途実施する。

## 変更内容

- `describeToken` helper を追加 (token 本体は露出せず、長さ + prefix 4 文字のみ)
- `githubHeaders`: Authorization ヘッダ生成時に token shape をログ
- `getGitHubToken`: `this.props` 伝播状況 (有無 / キー一覧 / githubUserId / githubLogin / token shape) をログ — 仮説 B (props 伝播失敗) 切り分け
- `get_doc_content`: entry ログを追加
- `get_doc_content` 401 時: `x-oauth-scopes` / `x-accepted-oauth-scopes` / `www-authenticate` / `x-github-request-id` / `x-ratelimit-*` を surface — 仮説 A (scope 不足) / 仮説 C (stale token) 切り分け

## 制約順守

- token 本体は一切ログに出ない (長さ + prefix 4 文字のみ)
- 既存成功系の挙動変化なし
- tsc --noEmit pass

## 影響スコープ

patch — 診断用ログ追加のみ。user/system observable な挙動変化なし。

Closes #98