### PR TITLE
chore(wrangler): sync observability config from dashboard (patch)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -50,3 +50,18 @@ crons = ["0 * * * *"]
 # Environment variables
 [vars]
 POLL_REPOS = "Liplus-Project/github-webhook-mcp,Liplus-Project/github-rag-mcp,Liplus-Project/liplus-desktop,Liplus-Project/liplus-language,Liplus-Project/dipper_ai"
+
+[observability]
+enabled = false
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false
+persist = true
+head_sampling_rate = 1


### PR DESCRIPTION
## 概要

Cloudflare Workers ダッシュボードで Opt-in した Observability (Workers Logs) の設定を `wrangler.toml` に同期する。ダッシュボード側のみに反映された状態は次回 `wrangler deploy` で silent に revert されるリスクがあるため、toml に固定化する。

## 変更内容

- `wrangler.toml` 末尾に 3 セクションを追記のみ (既存設定は変更しない)
  - `[observability]` — enabled=false, head_sampling_rate=1
  - `[observability.logs]` — enabled=true, persist=true, invocation_logs=true
  - `[observability.traces]` — enabled=false, persist=true
- 追記内容は Cloudflare ダッシュボードが提示した TOML と完全一致

## 影響範囲

patch (config sync のみ、user/system observable behavior 変化なし)。ダッシュボード状態と toml の整合を取るだけで、runtime 挙動は現行と同じ。

## 関連

- 元の調査: #98
- 判断記録: [liplus-language docs/e.-github-app-user-to-server-token-expiration.md](https://github.com/Liplus-Project/liplus-language/blob/main/docs/e.-github-app-user-to-server-token-expiration.md)

Closes #102