### PR TITLE
fix(wrangler): force reset RagMcpAgent DO to clear stale init() schema cache (patch)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
  *   POST /admin/reset-hashes?repo=owner/repo  -- Reset hashes and watermarks to trigger full re-embedding (requires GITHUB_TOKEN header)
  *
  * Durable Objects:
- *   RagMcpAgent  -- MCP server (tools: search_issues, get_issue_context, list_recent_activity)
+ *   RagMcpAgentV2  -- MCP server (tools: search_issues, get_issue_context, list_recent_activity)
  *   IssueStore   -- Issue/PR state store (SQLite-backed)
  *
  * Cron Trigger:
@@ -33,17 +33,17 @@ import {
 } from "./oauth.js";
 import { handleScheduled } from "./poller.js";
 import { handleWebhook } from "./webhook.js";
-import { RagMcpAgent } from "./mcp.js";
+import { RagMcpAgentV2 } from "./mcp.js";
 
 // Durable Object: issue/PR state store (SQLite-backed)
 export { IssueStore } from "./store.js";
 
 // Durable Object: MCP server (tools: search_issues, get_issue_context, list_recent_activity)
-export { RagMcpAgent } from "./mcp.js";
+export { RagMcpAgentV2 } from "./mcp.js";
 
 // McpAgent.serve() returns a fetch handler for MCP protocol.
 // It reads ctx.props (set by OAuthProvider) and passes them to the DO.
-const mcpHandler = RagMcpAgent.serve("/mcp");
+const mcpHandler = RagMcpAgentV2.serve("/mcp");
 
 /**
  * Inner handler -- processes requests after OAuthProvider routing.
@@ -129,7 +129,7 @@ const innerHandler: ExportedHandler<Env> = {
         return new Response("Unauthorized", { status: 401 });
       }
 
-      // Rewrite ctx.props to McpProps shape expected by RagMcpAgent.
+      // Rewrite ctx.props to McpProps shape expected by RagMcpAgentV2.
       // Pass the GitHub access token so the agent can make API calls.
       (ctx as unknown as { props: { githubUserId: number; githubLogin: string; accessToken: string } }).props = {
         githubUserId: props.githubUserId,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,5 +1,5 @@
 /**
- * RagMcpAgent — MCP server Durable Object exposing a single consolidated
+ * RagMcpAgentV2 — MCP server Durable Object exposing a single consolidated
  * semantic search tool.
  *
  * Tools:
@@ -65,7 +65,7 @@ function githubHeaders(token: string): Record<string, string> {
  */
 const INCLUDE_CONTENT_MAX_DOCS = 5;
 
-export class RagMcpAgent extends McpAgent<Env, unknown, McpProps> {
+export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
   // @ts-expect-error -- McpServer version mismatch between top-level SDK and agents' bundled copy (same issue as webhook-mcp; wrangler resolves at bundle time)
   server = new McpServer({
     name: "github-rag-mcp",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [durable_objects]
 bindings = [
-  { name = "MCP_OBJECT", class_name = "RagMcpAgent" },
+  { name = "MCP_OBJECT", class_name = "RagMcpAgentV2" },
   { name = "ISSUE_STORE", class_name = "IssueStore" }
 ]
 
@@ -13,13 +13,16 @@ bindings = [
 tag = "v1"
 new_sqlite_classes = ["RagMcpAgent", "IssueStore"]
 
-# v2: force reset RagMcpAgent to clear in-memory init() cache (tool schema enum).
-# IssueStore is preserved; indexed content (Vectorize + D1 FTS5) is untouched.
-# Required when init()-time schema definitions drift from deployed source (issue #109).
+# v2: rename MCP agent class to force fresh DO namespace + init().
+# Cloudflare rejects delete_classes while the binding still references the class,
+# so MCP_OBJECT is re-pointed to RagMcpAgentV2 before the old class is deleted.
+# Outcome: first request to MCP_OBJECT lands on a fresh RagMcpAgentV2 instance,
+# re-running init() and publishing the current 9-value type enum (issue #109).
+# IssueStore is untouched; indexed content in Vectorize + D1 FTS5 is preserved.
 [[migrations]]
 tag = "v2"
 deleted_classes = ["RagMcpAgent"]
-new_sqlite_classes = ["RagMcpAgent"]
+new_sqlite_classes = ["RagMcpAgentV2"]
 
 # KV namespace for OAuth provider (token, client, grant storage)
 [[kv_namespaces]]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,15 +13,15 @@ bindings = [
 tag = "v1"
 new_sqlite_classes = ["RagMcpAgent", "IssueStore"]
 
-# v2: rename MCP agent class to force fresh DO namespace + init().
-# Cloudflare rejects delete_classes while the binding still references the class,
-# so MCP_OBJECT is re-pointed to RagMcpAgentV2 before the old class is deleted.
-# Outcome: first request to MCP_OBJECT lands on a fresh RagMcpAgentV2 instance,
-# re-running init() and publishing the current 9-value type enum (issue #109).
+# v2: add RagMcpAgentV2 as a fresh class and re-point MCP_OBJECT binding to it.
+# First request to MCP_OBJECT now lands on a brand-new V2 instance and re-runs
+# init(), publishing the current 9-value type enum (issue #109).
+# Old RagMcpAgent DO instances remain in storage but are no longer bound or
+# referenced. Their deletion is deferred to a later PR to keep this migration
+# minimal and avoid the deleted_classes binding-coupling constraint.
 # IssueStore is untouched; indexed content in Vectorize + D1 FTS5 is preserved.
 [[migrations]]
 tag = "v2"
-deleted_classes = ["RagMcpAgent"]
 new_sqlite_classes = ["RagMcpAgentV2"]
 
 # KV namespace for OAuth provider (token, client, grant storage)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,6 +13,14 @@ bindings = [
 tag = "v1"
 new_sqlite_classes = ["RagMcpAgent", "IssueStore"]
 
+# v2: force reset RagMcpAgent to clear in-memory init() cache (tool schema enum).
+# IssueStore is preserved; indexed content (Vectorize + D1 FTS5) is untouched.
+# Required when init()-time schema definitions drift from deployed source (issue #109).
+[[migrations]]
+tag = "v2"
+deleted_classes = ["RagMcpAgent"]
+new_sqlite_classes = ["RagMcpAgent"]
+
 # KV namespace for OAuth provider (token, client, grant storage)
 [[kv_namespaces]]
 binding = "OAUTH_KV"


### PR DESCRIPTION
Closes #109

## 変更内容

`RagMcpAgent` Durable Object が init() で zod schema を cache しており、古い 6 値 `type` enum が MCP クライアントに surface され続けていた問題の修正。

- `src/mcp.ts`: class `RagMcpAgent` → `RagMcpAgentV2` へ rename
- `src/index.ts`: import/export/serve reference を V2 に更新
- `wrangler.toml`: MCP_OBJECT binding を V2 に切り替え、migration v2 に `new_sqlite_classes=["RagMcpAgentV2"]` 追加

V2 は別 DO namespace のため、最初の MCP リクエストで新 instance が cold start して init() が再走り、9 値 enum (issue_comment / pr_review / pr_review_comment を含む) が surface される。旧 `RagMcpAgent` storage は binding から外れた orphan として残る (別 PR で deleted_classes 経由で掃除予定)。

IssueStore / Vectorize / D1 FTS5 は触っていないため、indexed data のロスなし。

## ⚠️ Workers Builds が失敗している件について

Cloudflare dashboard のログで確定：

```
[ERROR] Version upload failed. You attempted to upload a version of a Worker
that includes a Durable Object migration, but migrations must be fully applied
via a non-versioned deployment. [code: 10211]
```

Workers Builds は versioned (gradual) deployment でデプロイするが、DO migration は非 versioned deploy でしか適用できない。このため migration tag を追加する PR は Workers Builds 側で**構造上必ず失敗する**。

### 手動適用手順 (Master)

merge 後、local から：

```bash
cd github-rag-mcp
git checkout main && git pull
npm run deploy   # = wrangler deploy (non-versioned)
```

一度 v2 migration が適用されれば、以降の versioned push は「v2 既適用」として通る。

### 適用後の検証

1. Claude Code / Desktop 再接続
2. `search_issues` の tool schema を確認 → `type` enum が 9 値になっていれば成功
3. `search_issues type=issue_comment sort=updated_desc top_k=5` 実行 → zod エラーなしで return