### PR TITLE
fix(mcp): retain RagMcpAgent stub to satisfy migration history (patch)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ import { RagMcpAgentV2 } from "./mcp.js";
 // Durable Object: issue/PR state store (SQLite-backed)
 export { IssueStore } from "./store.js";
 
+// Durable Object: MCP server — legacy stub (retained for migration compatibility only).
+export { RagMcpAgent } from "./mcp.js";
+
 // Durable Object: MCP server (tools: search_issues, get_issue_context, list_recent_activity)
 export { RagMcpAgentV2 } from "./mcp.js";
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -12,6 +12,7 @@
  * idFromName("user-{githubUserId}").
  */
 
+import { DurableObject } from "cloudflare:workers";
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -64,6 +65,20 @@ function githubHeaders(token: string): Record<string, string> {
  * additional queries rather than lifting this cap.
  */
 const INCLUDE_CONTENT_MAX_DOCS = 5;
+
+/**
+ * Legacy class retained solely to satisfy Cloudflare's "class must exist in
+ * script for classes declared in past migrations (v1 new_sqlite_classes)"
+ * constraint. MCP_OBJECT binding points to RagMcpAgentV2 now, so this class
+ * never receives live traffic. It exists only so `wrangler deploy` does not
+ * fail with "script does not export class 'RagMcpAgent'". A follow-up PR can
+ * delete this class together with a deleted_classes migration.
+ */
+export class RagMcpAgent extends DurableObject<Env> {
+  async fetch(): Promise<Response> {
+    return new Response("RagMcpAgent has been retired; use RagMcpAgentV2", { status: 410 });
+  }
+}
 
 export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
   // @ts-expect-error -- McpServer version mismatch between top-level SDK and agents' bundled copy (same issue as webhook-mcp; wrangler resolves at bundle time)


### PR DESCRIPTION
Closes #111
Refs #109

#109 の merge 後 deploy が code 10064 ("script does not export class 'RagMcpAgent'") で失敗した件の修正。旧 `RagMcpAgent` を空の `DurableObject` stub として残し、Cloudflare の「過去 migration で declare されたクラスは script に存在し続けること」制約を満たす。stub には binding が無いため traffic を受けない。