### PR TITLE
fix(search): repair sparse FTS5 and guard empty rerank input (patch)

### DIFF
--- a/docs/0-requirements.ja.md
+++ b/docs/0-requirements.ja.md
@@ -253,6 +253,7 @@ score(d) = sum_over_rankers ( 1 / (k + rank_r(d)) )
 実装制約と既知の限界:
 
 - bge-reranker-base は context window 512 tokens（BAAI 元仕様）。`(query, candidate content)` pair が超過しないよう char-budget ベースで truncate（query 200 chars 上限、pair 合計 1700 chars 上限）
+- Workers AI は `contexts[].text` に length >= 1 を要求（エラー 5006: "Length of '/contexts/N/text' must be >= 1 not met"）。sparse hit が無い dense-only 候補は content が空文字になるため、rerank 入力から事前に除外する（除外件数が 0 / 1 の場合は AI 呼び出しをスキップして passthrough）
 - reranker は最大 50 件 / 1 検索（Workers AI Free tier 10,000 neurons/day と業界中央値の整合点）
 - bge-reranker-base は英語ベース・多言語非対応。日本語 issue/PR では精度低下リスクあり（runtime 観察対象、将来的に bge-reranker-v2-m3 提供開始時または外部 reranker への切替を別 issue で検討）
 - reranker 呼び出し失敗・想定外レスポンス時は graceful fallback（fusion 順を維持、`rerank_applied: false` で通知）

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -253,6 +253,7 @@ Rationale:
 Implementation constraints and known limitations:
 
 - bge-reranker-base inherits BAAI's 512-token context window. Each `(query, candidate content)` pair is truncated by character budget (query: 200 chars max, pair total: 1700 chars max) since no tokenizer is available in Workers.
+- Workers AI requires every `contexts[].text` to be at least one character long (error 5006: "Length of '/contexts/N/text' must be >= 1 not met"). Dense-only candidates that lack an FTS row have empty content, so they are filtered out of the rerank input before the call; if 0 or 1 non-empty candidates remain the call is skipped entirely.
 - The reranker processes at most 50 candidates per call — chosen as the join point between the Workers AI Free tier neuron budget (10,000/day) and industry median (50–75 candidates).
 - bge-reranker-base is English-centric and not multilingual. Japanese issue/PR content may see degraded quality. This is observed at runtime; switching to `bge-reranker-v2-m3` or an external reranker (Voyage / Cohere) is tracked as a separate issue when needed.
 - On reranker call failure or unexpected response shape, the system falls back gracefully to the post-filter (RRF) order and reports `rerank_applied: false`.

--- a/src/fts.ts
+++ b/src/fts.ts
@@ -218,27 +218,38 @@ export async function queryFts(
   // then picks the best BM25 score across both. `bm25()` returns negative values
   // in D1's FTS5 (larger-magnitude negative = better match), so ASC orders
   // best-first regardless of sign.
+  //
+  // Per-branch `ORDER BY score ASC LIMIT ?` must live inside a subquery because
+  // SQLite's compound SELECT (UNION ALL) forbids LIMIT directly on its arms —
+  // D1 rejects such queries with `D1_ERROR: LIMIT clause should come after
+  // UNION ALL not before` (observed via Workers Observability, 2026-04-24).
   const sql = `
     SELECT * FROM (
-      SELECT d.vector_id AS vector_id, d.repo, d.type, d.state, d.labels,
-             d.milestone, d.assignees, d.updated_at,
-             d.number, d.tag_name, d.doc_path, d.commit_sha, d.file_path, d.file_status,
-             d.commit_date, d.commit_author, d.content,
-             bm25(search_docs_nat_fts) AS score
-        FROM search_docs_nat_fts f
-        JOIN search_docs d ON d.rowid = f.rowid
-       WHERE search_docs_nat_fts MATCH ?${whereSql}
-       LIMIT ?
+      SELECT * FROM (
+        SELECT d.vector_id AS vector_id, d.repo, d.type, d.state, d.labels,
+               d.milestone, d.assignees, d.updated_at,
+               d.number, d.tag_name, d.doc_path, d.commit_sha, d.file_path, d.file_status,
+               d.commit_date, d.commit_author, d.content,
+               bm25(search_docs_nat_fts) AS score
+          FROM search_docs_nat_fts f
+          JOIN search_docs d ON d.rowid = f.rowid
+         WHERE search_docs_nat_fts MATCH ?${whereSql}
+         ORDER BY score ASC
+         LIMIT ?
+      )
       UNION ALL
-      SELECT d.vector_id AS vector_id, d.repo, d.type, d.state, d.labels,
-             d.milestone, d.assignees, d.updated_at,
-             d.number, d.tag_name, d.doc_path, d.commit_sha, d.file_path, d.file_status,
-             d.commit_date, d.commit_author, d.content,
-             bm25(search_docs_code_fts) AS score
-        FROM search_docs_code_fts f
-        JOIN search_docs d ON d.rowid = f.rowid
-       WHERE search_docs_code_fts MATCH ?${whereSql}
-       LIMIT ?
+      SELECT * FROM (
+        SELECT d.vector_id AS vector_id, d.repo, d.type, d.state, d.labels,
+               d.milestone, d.assignees, d.updated_at,
+               d.number, d.tag_name, d.doc_path, d.commit_sha, d.file_path, d.file_status,
+               d.commit_date, d.commit_author, d.content,
+               bm25(search_docs_code_fts) AS score
+          FROM search_docs_code_fts f
+          JOIN search_docs d ON d.rowid = f.rowid
+         WHERE search_docs_code_fts MATCH ?${whereSql}
+         ORDER BY score ASC
+         LIMIT ?
+      )
     )
     ORDER BY score ASC
     LIMIT ?

--- a/src/rerank.ts
+++ b/src/rerank.ts
@@ -97,9 +97,12 @@ type RerankerResponse =
  *
  * Behavior:
  * - Returns a new array sorted by reranker score, descending. Length is
- *   `min(candidates.length, topK ?? candidates.length, RERANK_MAX_CANDIDATES_after_clamp)`.
- * - Empty `candidates` returns an empty array immediately (no AI call).
- * - Single-element `candidates` returns a passthrough with a synthesized
+ *   `min(nonEmpty.length, topK ?? nonEmpty.length, RERANK_MAX_CANDIDATES_after_clamp)`,
+ *   where `nonEmpty` is the input with empty / whitespace-only content removed.
+ * - Candidates with empty content are silently excluded — Workers AI rejects
+ *   any `contexts[].text` shorter than one character with error 5006.
+ * - Empty input (or all-empty content) returns an empty array immediately (no AI call).
+ * - A single non-empty candidate returns a passthrough with a synthesized
  *   score of 1, to avoid burning a Workers AI call on a one-element list.
  * - Any thrown error from `env.AI.run` or any malformed response returns
  *   `null` so the caller can keep the original (pre-rerank) order.
@@ -116,13 +119,21 @@ export async function rerankCandidates(
   candidates: RerankCandidate[],
   topK?: number,
 ): Promise<RerankResult[] | null> {
-  if (candidates.length === 0) return [];
-  if (candidates.length === 1) {
-    return [{ id: candidates[0].id, score: 1 }];
+  // Drop candidates whose content is empty or whitespace-only. Workers AI's
+  // `@cf/baai/bge-reranker-base` rejects requests where any `contexts[].text`
+  // is shorter than one character with error 5006 ("Length of
+  // '/contexts/N/text' must be >= 1 not met"). Passing the call through
+  // unfiltered would make the entire rerank return null and leave the caller
+  // with the pre-rerank order even for candidates that do have signal.
+  const nonEmptyCandidates = candidates.filter((c) => c.content.trim() !== "");
+
+  if (nonEmptyCandidates.length === 0) return [];
+  if (nonEmptyCandidates.length === 1) {
+    return [{ id: nonEmptyCandidates[0].id, score: 1 }];
   }
 
   // Defensive clamp on candidate count.
-  const trimmedCandidates = candidates.slice(0, RERANK_MAX_CANDIDATES);
+  const trimmedCandidates = nonEmptyCandidates.slice(0, RERANK_MAX_CANDIDATES);
 
   // Build (query, contexts) payload with per-pair truncation. The query is
   // shared across all pairs; we still truncate it once up front.


### PR DESCRIPTION
## Summary

`search_issues` の cross-encoder reranker が恒常的に発火しない現象を修正する。原因は FTS5 SQL の構文バグと、その下流で発生する Workers AI 5006 エラーの二段カスケード。

## 根因

production log (2026-04-24 Cloudflare Workers Observability) より、同一検索で以下 2 件のエラーが連鎖していた:

1. **FTS5 SQL 構文エラー（真の根因）**
   ```
   search_issues: D1 FTS5 query failed:
     D1_ERROR: LIMIT clause should come after UNION ALL not before
   ```
   compound SELECT (UNION ALL) の各ブランチ内に `LIMIT ?` を直接置いていた。SQLite / D1 の構文では parenthesize / subquery-wrap なしでは末尾ブロックにしか LIMIT を置けないため、毎回 throw → `mcp.ts` が silent swallow → sparse 常に 0。

2. **bge-reranker-base 5006 エラー（下流症状）**
   ```
   rerankCandidates: bge-reranker-base call failed:
     5006: Error: Length of '/contexts/0/text' must be >= 1 not met
   ```
   sparse が 0 のため rerank 入力は全件 dense-only（FtsRow なし、content 空文字）。Workers AI が length >= 1 制約で reject → `rerank_applied: false` が継続。

## 変更内容

- `src/fts.ts`: 各 UNION ALL ブランチを subquery でラップし、`ORDER BY score ASC LIMIT ?` を有効な位置に移動。D1 構文違反を解消。
- `src/rerank.ts`: content が空文字 / 空白のみの候補を rerank 入力から事前除外。残 0/1 件の場合は AI 呼び出しをスキップ（defense-in-depth、FTS が真にヒットしないクエリでも 5006 を踏まない）。
- `docs/0-requirements.md` / `docs/0-requirements.ja.md`: Workers AI の `contexts[].text >= 1` 制約と除外挙動を reranker 実装制約セクションに追記。

## 期待挙動

修正後、dense hit と sparse hit が両方返り、RRF 合成後の候補を bge-reranker-base が re-score できる。`rerank_applied: true` が返るケースが本来の運用になる。

## Test plan

- [ ] CI（既存 lint / type-check）pass
- [ ] 本番 deploy 後、`search_issues` に semantic query を投げて `sparse_candidates > 0` と `rerank_applied: true` を確認
- [ ] Workers Observability で `rerankCandidates: bge-reranker-base call failed` / `search_issues: D1 FTS5 query failed` が新規発生しないことを確認

Closes #97