### PR TITLE
fix(d1): rebuild FTS5 virtual tables to recover from VTAB corruption (patch)

### DIFF
--- a/migrations/0002_fts5_rebuild.sql
+++ b/migrations/0002_fts5_rebuild.sql
@@ -1,0 +1,24 @@
+-- FTS5 virtual table rebuild — recover from SQLITE_CORRUPT_VTAB
+--
+-- Layer = L4 Operations (sparse retrieval surface recovery)
+--
+-- Context:
+--   Observed on 2026-04-24: `search_issues` sparse path and FTS upserts both
+--   failed with `D1_ERROR: database disk image is malformed: SQLITE_CORRUPT
+--   (extended: SQLITE_CORRUPT_VTAB)`. The content-owner table `search_docs`
+--   was intact (1109 rows, direct bm25 queries via `wrangler d1 execute`
+--   succeeded), so only the FTS5 virtual tables were corrupt.
+--
+-- Recovery:
+--   FTS5's built-in `'rebuild'` command re-populates the virtual table from
+--   the content-owner table (`search_docs`). The operation is idempotent and
+--   non-destructive — it reads every row of `search_docs` and re-indexes it
+--   through each tokenizer. On a healthy or empty FTS table it is effectively
+--   a no-op, so this migration is safe to re-run.
+--
+-- Scope:
+--   Covers both FTS5 tables (nat + code). Triggers from 0001 keep subsequent
+--   upserts in sync automatically.
+
+INSERT INTO search_docs_nat_fts(search_docs_nat_fts) VALUES('rebuild');
+INSERT INTO search_docs_code_fts(search_docs_code_fts) VALUES('rebuild');


### PR DESCRIPTION
## Summary

D1 FTS5 仮想テーブルの corruption を復旧する migration を追加する。

## 根因（production log + wrangler d1 直接検証で確定）

PR #116 で FTS5 SQL 構文バグ（LIMIT before UNION ALL）を直したら、従来 silent swallow されていた実行経路の下で VTAB corruption が露出した:

```
search_issues: D1 FTS5 query failed:
  D1_ERROR: database disk image is malformed:
  SQLITE_CORRUPT (extended: SQLITE_CORRUPT_VTAB)
```

- `search_docs`（content-owner）は健全: 1109 行、`wrangler d1 execute --remote` で bm25 直接クエリ成功
- `search_docs_nat_fts` / `search_docs_code_fts`（virtual tables）だけが破損

## 変更内容

`migrations/0002_fts5_rebuild.sql` を追加し、FTS5 built-in の `'rebuild'` コマンドで両仮想テーブルを content-owner から再構築する。

- idempotent（再実行しても副作用なし、healthy / empty FTS では no-op）
- 非破壊（`search_docs` には触れない、仮想テーブル側のみ再構築）

## 適用状況

既に `wrangler d1 execute github-rag-fts --remote` で本番に直接適用済み:

- `search_docs_nat_fts`: 2778 changes
- `search_docs_code_fts`: 12719 changes

適用後、`search_issues` クエリで `sparse_candidates: 15` / `rerank_applied: true` / `rerank_score: 0.94 等` を確認。3 段 retrieval（dense + sparse + cross-encoder rerank）が完全復旧。

本 migration ファイルは:

- 将来の D1 fresh setup 時に `wrangler d1 migrations apply` から自動再現
- VTAB corruption 再発時の復旧手順の正式記録

## Test plan

- [x] 本番 D1 に直接適用し、sparse > 0 と rerank_score 付与を確認済み
- [ ] CI pass
- [ ] Workers Observability で `SQLITE_CORRUPT_VTAB` / `Failed to upsert FTS5 row` が新規発生しないことを確認

## 備考

VTAB corruption の根因（何がきっかけで corrupt state に入ったか）は未特定。再発した場合、同 migration を追記（0003, 0004...）する運用で回せる。恒久的な防御は別 issue に切り出す想定。

Closes #117