### PR TITLE
fix(poller): split cron into light + heavy invocations to fit subrequest budget (patch)

### DIFF
--- a/docs/0-requirements.ja.md
+++ b/docs/0-requirements.ja.md
@@ -114,7 +114,12 @@ Responsibilities:
 - issue、pull request、release、docs、issue/PR comments、commit diff の変更を再取得する
 - 一時障害後も store を収束させる
 
-現在の deployment では hourly で実行する。
+現在の deployment では hourly で 2 つの cron trigger に分けて実行する。1 つの cron invocation に全 surface を詰め込むと Cloudflare Workers の per-Worker subrequest 上限に達するため、light / heavy で分割する:
+
+- **`0 * * * *` (light)** — issues / pull requests / releases / docs
+- **`30 * * * *` (heavy)** — issue/PR comments / commit diffs
+
+各 invocation は独立した subrequest 予算を持つので、後段 repo が尾切れする問題が発生しない。dispatch は `controller.cron` で `handleScheduled` 内で行う。
 
 commit diff poller は 2-phase 構成:
 

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -114,7 +114,12 @@ Responsibilities:
 - refresh changed issues, pull requests, releases, docs, issue/PR comments, and commit diffs
 - keep the stores converged even after transient failures
 
-The poller runs hourly in the current deployment.
+The poller runs hourly in the current deployment, split across two cron triggers so each invocation gets its own Cloudflare Workers subrequest budget. Bundling every surface into one invocation hits the per-Worker limit on the busiest repository:
+
+- **`0 * * * *` (light)** — issues, pull requests, releases, docs
+- **`30 * * * *` (heavy)** — issue/PR comments, commit diffs
+
+Dispatch is performed inside `handleScheduled` by inspecting `controller.cron`.
 
 The commit-diff poller runs in two phases:
 

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1188,23 +1188,107 @@ export async function pollDiffs(
   );
 }
 
+/** Cron expression that triggers the light-surface dispatch (issues / releases / docs). */
+const LIGHT_CRON = "0 * * * *";
+/** Cron expression that triggers the heavy-surface dispatch (comments / diffs). */
+const HEAVY_CRON = "30 * * * *";
+
 /**
- * Main scheduled handler — called by Cron Trigger hourly as fallback.
- * Polls all configured repositories for issue/PR updates.
+ * Run the lightweight surfaces (issues, releases, docs) for one repo.
+ * Errors in any one call are logged but do not stop subsequent surfaces or repos.
+ */
+async function runLightSurfaces(
+  repo: string,
+  env: Env,
+  storeStub: DurableObjectStub,
+): Promise<void> {
+  try {
+    await pollRepo(repo, env, storeStub);
+  } catch (err) {
+    console.error(
+      `Failed to poll ${repo}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  try {
+    await pollReleases(repo, env, storeStub);
+  } catch (err) {
+    console.error(
+      `Failed to poll releases for ${repo}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  try {
+    await pollDocs(repo, env, storeStub);
+  } catch (err) {
+    console.error(
+      `Failed to poll docs for ${repo}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/**
+ * Run the heavy surfaces (comments, commit diffs) for one repo.
+ * These two consume the bulk of the Workers subrequest budget so they live
+ * in a separate cron invocation from the light surfaces (see issue #120).
+ */
+async function runHeavySurfaces(
+  repo: string,
+  env: Env,
+  storeStub: DurableObjectStub,
+): Promise<void> {
+  try {
+    await pollComments(repo, env, storeStub);
+  } catch (err) {
+    console.error(
+      `Failed to poll comments for ${repo}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  try {
+    await pollDiffs(repo, env, storeStub);
+  } catch (err) {
+    console.error(
+      `Failed to poll diffs for ${repo}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/**
+ * Main scheduled handler — dispatched by cron expression so each invocation
+ * gets its own Cloudflare Workers subrequest budget.
+ *
+ * Two cron triggers fire hourly, staggered by 30 minutes:
+ *
+ *   - `LIGHT_CRON` (`:00`)  → issues / releases / docs across all repos
+ *   - `HEAVY_CRON` (`:30`)  → comments / diffs across all repos
+ *
+ * Bundling all surfaces into a single invocation exhausts the per-Worker
+ * subrequest limit on busy repositories and surfaces "Too many subrequests"
+ * failures on whichever repo lands at the tail of POLL_REPOS. Splitting the
+ * heavy comment + diff polling into its own cron leaves each invocation with
+ * a fresh budget.
+ *
+ * Unrecognised cron expressions fall through to a no-op log so that adding a
+ * future cron line in `wrangler.toml` does not silently re-introduce the
+ * "every surface in one invocation" pattern.
  */
 export async function handleScheduled(
   controller: ScheduledController,
   env: Env,
   ctx: ExecutionContext,
 ): Promise<void> {
-  console.log("[poller] Running hourly fallback sync");
   console.log(
-    "Cron trigger fired:",
+    "[poller] Cron trigger fired:",
     controller.cron,
     new Date(controller.scheduledTime).toISOString(),
   );
 
-  // Parse repository list from env
   const repos = env.POLL_REPOS
     ? env.POLL_REPOS.split(",")
         .map((r) => r.trim())
@@ -1225,52 +1309,21 @@ export async function handleScheduled(
   const storeId = env.ISSUE_STORE.idFromName("global");
   const storeStub = env.ISSUE_STORE.get(storeId);
 
-  // Poll each repository sequentially to stay within rate limits
-  for (const repo of repos) {
-    try {
-      await pollRepo(repo, env, storeStub);
-    } catch (err) {
-      console.error(
-        `Failed to poll ${repo}:`,
-        err instanceof Error ? err.message : String(err),
-      );
-      // Continue polling other repos even if one fails
+  if (controller.cron === LIGHT_CRON) {
+    for (const repo of repos) {
+      await runLightSurfaces(repo, env, storeStub);
     }
-
-    try {
-      await pollReleases(repo, env, storeStub);
-    } catch (err) {
-      console.error(
-        `Failed to poll releases for ${repo}:`,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-
-    try {
-      await pollDocs(repo, env, storeStub);
-    } catch (err) {
-      console.error(
-        `Failed to poll docs for ${repo}:`,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-
-    try {
-      await pollComments(repo, env, storeStub);
-    } catch (err) {
-      console.error(
-        `Failed to poll comments for ${repo}:`,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-
-    try {
-      await pollDiffs(repo, env, storeStub);
-    } catch (err) {
-      console.error(
-        `Failed to poll diffs for ${repo}:`,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
+    return;
   }
+
+  if (controller.cron === HEAVY_CRON) {
+    for (const repo of repos) {
+      await runHeavySurfaces(repo, env, storeStub);
+    }
+    return;
+  }
+
+  console.warn(
+    `[poller] Unknown cron expression "${controller.cron}" — no dispatch configured`,
+  );
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -49,9 +49,14 @@ migrations_dir = "migrations"
 [ai]
 binding = "AI"
 
-# Cron Triggers — hourly fallback poll (primary updates via webhook)
+# Cron Triggers — hourly fallback poll (primary updates via webhook).
+# Split into two invocations so each gets its own Workers subrequest budget;
+# bundling all surfaces into a single invocation hits the per-Worker limit on
+# the last (busiest) repo. See issue #120.
+#   :00 — light surfaces (issues, releases, docs)
+#   :30 — heavy surfaces (comments, diffs)
 [triggers]
-crons = ["0 * * * *"]
+crons = ["0 * * * *", "30 * * * *"]
 
 # Required secrets (set via `wrangler secret put <NAME>`):
 # GITHUB_CLIENT_ID      — GitHub App OAuth client ID


### PR DESCRIPTION
## Summary

`handleScheduled` を 1 つの cron invocation で全 surface を処理する設計から、light / heavy の 2 cron 分割に変更する。Cloudflare Workers の per-invocation subrequest 上限を超えないように、heavy surface (pollComments + pollDiffs) を独立 invocation に分離する。

## 根因

production log (2026-04-25 17:01 JST) で 191 errors、全件 `Too many subrequests by single Worker`:

```
pollDiffs: backward list failed for Liplus-Project/dipper_ai: Too many subrequests
pollDiffs: forward list failed for Liplus-Project/dipper_ai: Too many subrequests
pollComments: failed to fetch comments for Liplus-Project/dipper_ai#50: Too many subrequests
...
```

`handleScheduled` が 1 invocation で 5 repos × 5 surfaces を順次処理、subrequest が累積し POLL_REPOS 末尾 (dipper_ai) で予算枯渇。v0.7.0 の `pollComments` 単体でも既にギリギリで、v0.8.2 の `pollDiffs` (~22 subrequests/repo) 追加が決定打。

## 変更内容

### `wrangler.toml`
```toml
[triggers]
crons = ["0 * * * *", "30 * * * *"]
```

### `src/poller.ts`
- `handleScheduled` を `controller.cron` で dispatch する形に refactor
- light 経路 (`runLightSurfaces`): `pollRepo` + `pollReleases` + `pollDocs`
- heavy 経路 (`runHeavySurfaces`): `pollComments` + `pollDiffs`
- 未知の cron 表現は `console.warn` で no-op log のみ（将来の cron 追加時の silent regression 防止）

### `docs/0-requirements.md` / `docs/0-requirements.ja.md`
- Cron Poller 節に 2-cron 分割スケジュールと dispatch 方式を追記

## 期待挙動

- 各 cron invocation が独立した Workers subrequest 予算 (paid plan 1000) を持つので、busiest repo (dipper_ai) でも予算枯渇しない
- カバレッジは維持（hourly での全 surface 取得は変わらず、heavy surface が 30 分ずれるだけ）
- 既存 watermark / store API は変更なし

## Test plan

- [ ] CI (lint / type-check) pass
- [ ] Workers Builds pass
- [ ] Deploy 後、次の `:00` cron で light 経路ログ、`:30` cron で heavy 経路ログを確認
- [ ] `Too many subrequests by single Worker` エラーが新規発生しないことを Observability で確認

Closes #120