### PR TITLE
fix(poller): isolate comments and diffs into separate crons (patch)

### DIFF
--- a/docs/0-requirements.ja.md
+++ b/docs/0-requirements.ja.md
@@ -114,12 +114,13 @@ Responsibilities:
 - issue、pull request、release、docs、issue/PR comments、commit diff の変更を再取得する
 - 一時障害後も store を収束させる
 
-現在の deployment では hourly で 2 つの cron trigger に分けて実行する。1 つの cron invocation に全 surface を詰め込むと Cloudflare Workers の per-Worker subrequest 上限に達するため、light / heavy で分割する:
+現在の deployment では hourly で 3 つの cron trigger に分けて実行する。各 upsert が Store DO + Vectorize + D1 FTS + AI embed と最大 4 internal fetch を生むため、heavy 同居 (comments + diffs) でも per-Worker subrequest 上限を超える。surface 単独単位で 15 分ずつずらして発火させる:
 
 - **`0 * * * *` (light)** — issues / pull requests / releases / docs
-- **`30 * * * *` (heavy)** — issue/PR comments / commit diffs
+- **`15 * * * *` (comments)** — issue/PR comments のみ
+- **`30 * * * *` (diffs)** — commit diffs のみ
 
-各 invocation は独立した subrequest 予算を持つので、後段 repo が尾切れする問題が発生しない。dispatch は `controller.cron` で `handleScheduled` 内で行う。
+各 invocation は独立した subrequest 予算を持つ。dispatch は `controller.cron` で `handleScheduled` 内で行う。未知の cron 表現は no-op log で silent regression を防止する。
 
 commit diff poller は 2-phase 構成:
 

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -114,12 +114,13 @@ Responsibilities:
 - refresh changed issues, pull requests, releases, docs, issue/PR comments, and commit diffs
 - keep the stores converged even after transient failures
 
-The poller runs hourly in the current deployment, split across two cron triggers so each invocation gets its own Cloudflare Workers subrequest budget. Bundling every surface into one invocation hits the per-Worker limit on the busiest repository:
+The poller runs hourly in the current deployment, split across three cron triggers so each invocation gets its own Cloudflare Workers subrequest budget. Each upsert fans out to Store DO + Vectorize + D1 FTS + AI embed (up to four internal subrequests), so even the comments + diffs combination overshoots the per-Worker ceiling on busy repositories; the heavy surfaces run one-per-cron, staggered by 15 minutes:
 
 - **`0 * * * *` (light)** — issues, pull requests, releases, docs
-- **`30 * * * *` (heavy)** — issue/PR comments, commit diffs
+- **`15 * * * *` (comments)** — issue / PR comments only
+- **`30 * * * *` (diffs)** — commit diffs only
 
-Dispatch is performed inside `handleScheduled` by inspecting `controller.cron`.
+Dispatch is performed inside `handleScheduled` by inspecting `controller.cron`. Unknown cron expressions fall through to a no-op log to prevent silent regressions when triggers are added later.
 
 The commit-diff poller runs in two phases:
 

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1190,8 +1190,10 @@ export async function pollDiffs(
 
 /** Cron expression that triggers the light-surface dispatch (issues / releases / docs). */
 const LIGHT_CRON = "0 * * * *";
-/** Cron expression that triggers the heavy-surface dispatch (comments / diffs). */
-const HEAVY_CRON = "30 * * * *";
+/** Cron expression that triggers the comments-only dispatch. */
+const COMMENTS_CRON = "15 * * * *";
+/** Cron expression that triggers the diffs-only dispatch. */
+const DIFFS_CRON = "30 * * * *";
 
 /**
  * Run the lightweight surfaces (issues, releases, docs) for one repo.
@@ -1231,11 +1233,12 @@ async function runLightSurfaces(
 }
 
 /**
- * Run the heavy surfaces (comments, commit diffs) for one repo.
- * These two consume the bulk of the Workers subrequest budget so they live
- * in a separate cron invocation from the light surfaces (see issue #120).
+ * Run the comment-backfill surface for one repo.
+ * Lives in its own cron invocation because each comment upsert fans out to
+ * Store DO + Vectorize + D1 FTS + AI embed and the 5-repo aggregate alone
+ * approaches the per-Worker subrequest ceiling (issue #122).
  */
-async function runHeavySurfaces(
+async function runCommentsSurface(
   repo: string,
   env: Env,
   storeStub: DurableObjectStub,
@@ -1248,7 +1251,18 @@ async function runHeavySurfaces(
       err instanceof Error ? err.message : String(err),
     );
   }
+}
 
+/**
+ * Run the commit-diff (forward + backward) surface for one repo.
+ * Same isolation rationale as `runCommentsSurface` — each diff upsert also
+ * fans out to several internal subrequests so it gets its own invocation.
+ */
+async function runDiffsSurface(
+  repo: string,
+  env: Env,
+  storeStub: DurableObjectStub,
+): Promise<void> {
   try {
     await pollDiffs(repo, env, storeStub);
   } catch (err) {
@@ -1263,18 +1277,19 @@ async function runHeavySurfaces(
  * Main scheduled handler — dispatched by cron expression so each invocation
  * gets its own Cloudflare Workers subrequest budget.
  *
- * Two cron triggers fire hourly, staggered by 30 minutes:
+ * Three cron triggers fire hourly, staggered by 15 minutes:
  *
- *   - `LIGHT_CRON` (`:00`)  → issues / releases / docs across all repos
- *   - `HEAVY_CRON` (`:30`)  → comments / diffs across all repos
+ *   - `LIGHT_CRON`    (`:00`) → issues / releases / docs across all repos
+ *   - `COMMENTS_CRON` (`:15`) → issue / PR comments across all repos
+ *   - `DIFFS_CRON`    (`:30`) → commit diffs (forward + backward) across all repos
  *
- * Bundling all surfaces into a single invocation exhausts the per-Worker
- * subrequest limit on busy repositories and surfaces "Too many subrequests"
- * failures on whichever repo lands at the tail of POLL_REPOS. Splitting the
- * heavy comment + diff polling into its own cron leaves each invocation with
- * a fresh budget.
+ * Bundling all surfaces (or even just comments + diffs) into a single
+ * invocation exhausts the per-Worker subrequest limit on busy repositories
+ * because every upsert fans out to Store DO + Vectorize + D1 FTS + AI embed.
+ * Splitting heavy surfaces one-per-cron leaves each invocation with a fresh
+ * budget for its single surface across all repos.
  *
- * Unrecognised cron expressions fall through to a no-op log so that adding a
+ * Unrecognised cron expressions fall through to a no-op log so adding a
  * future cron line in `wrangler.toml` does not silently re-introduce the
  * "every surface in one invocation" pattern.
  */
@@ -1316,9 +1331,16 @@ export async function handleScheduled(
     return;
   }
 
-  if (controller.cron === HEAVY_CRON) {
+  if (controller.cron === COMMENTS_CRON) {
     for (const repo of repos) {
-      await runHeavySurfaces(repo, env, storeStub);
+      await runCommentsSurface(repo, env, storeStub);
+    }
+    return;
+  }
+
+  if (controller.cron === DIFFS_CRON) {
+    for (const repo of repos) {
+      await runDiffsSurface(repo, env, storeStub);
     }
     return;
   }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -50,13 +50,15 @@ migrations_dir = "migrations"
 binding = "AI"
 
 # Cron Triggers — hourly fallback poll (primary updates via webhook).
-# Split into two invocations so each gets its own Workers subrequest budget;
-# bundling all surfaces into a single invocation hits the per-Worker limit on
-# the last (busiest) repo. See issue #120.
-#   :00 — light surfaces (issues, releases, docs)
-#   :30 — heavy surfaces (comments, diffs)
+# Each surface group runs in its own invocation so it gets a fresh Workers
+# subrequest budget. Bundling comments + diffs together still tripped the
+# per-Worker limit (issue #122) because each upsert fans out to Store DO +
+# Vectorize + D1 FTS + AI embed.
+#   :00 — light surfaces  (issues, releases, docs)
+#   :15 — comments surface (pollComments)
+#   :30 — diffs surface    (pollDiffs)
 [triggers]
-crons = ["0 * * * *", "30 * * * *"]
+crons = ["0 * * * *", "15 * * * *", "30 * * * *"]
 
 # Required secrets (set via `wrangler secret put <NAME>`):
 # GITHUB_CLIENT_ID      — GitHub App OAuth client ID


### PR DESCRIPTION
## Summary

PR #121 で 2-cron 分割した heavy 側 (pollComments + pollDiffs) でも依然 subrequest 上限超過 (2026-04-25 18:30 JST、140 errors)。各 upsert が Store DO + Vectorize + D1 FTS + AI embed と最大 4 internal subrequest を生むため、heavy 同居でも持たない。本 PR で heavy を 1 surface ずつ独立 cron に分離する。

Closes #122

## 観測（PR #121 deploy 後の初 heavy cron）

```
pollDiffs: backward list failed for Liplus-Project/dipper_ai
pollComments: failed to fetch comments for Liplus-Project/dipper_ai#10
pollComments: failed to fetch review comments for Liplus-Project/liplus-language#1154
pollComments: failed to fetch review comments for Liplus-Project/liplus-desktop#67
... (140 errors total)
```

light cron (`0 * * * *`) は完全クリーン。問題は heavy 側の同居のみ。

## 変更内容

### `wrangler.toml`
```toml
[triggers]
crons = ["0 * * * *", "15 * * * *", "30 * * * *"]
```

### `src/poller.ts`
- `runHeavySurfaces` を `runCommentsSurface` と `runDiffsSurface` に分離
- `handleScheduled` を `LIGHT_CRON` / `COMMENTS_CRON` / `DIFFS_CRON` の 3-way dispatch に拡張
- 未知 cron expression は依然 no-op log のみ（silent regression 防止）

### `docs/0-requirements.md` / `docs/0-requirements.ja.md`
- Cron Poller 節を 2 cron → 3 cron に書き換え、root cause の "upsert fanout = 4 internal subrequests" を明記

## 期待挙動

各 cron invocation は単独 surface × 5 repos のみを処理する:

| cron      | 1 invocation あたり試算 | 上限 1000 への余裕 |
|-----------|------------------------:|--------------------:|
| `:00` light    | ~150              | 大                  |
| `:15` comments | ~600              | 中                  |
| `:30` diffs    | ~440              | 中                  |

dipper_ai のような busiest repo でも単独 surface なら確実に予算内。

## Test plan

- [ ] CI (lint / type-check) pass
- [ ] Workers Builds pass
- [ ] Deploy 後、次の `:00` / `:15` / `:30` の各 cron で対応 surface ログのみが出ること
- [ ] `Too many subrequests by single Worker` エラーが新規発生しないことを Observability で確認

## 備考

POLL_REPOS をさらに増やした場合、comments cron が再度上限到達する可能性あり。その時は per-repo round-robin (5 cron で各 repo を分け持ち) が次手。本 PR では現 5 repos の budget 整合のみ対応。