### PR TITLE
fix(poller): halve diff commit caps to fit Workers subrequest budget (patch)

### DIFF
--- a/src/poller.ts
+++ b/src/poller.ts
@@ -53,15 +53,17 @@ const MAX_COMMENTS_EMBEDDED_PER_REPO = 30;
 /** Maximum number of commits fetched in the forward (webhook-redundancy) phase
  *  of the diff poller per repo per run.
  *  Forward is normally a no-op because the webhook path already indexes new
- *  commits; this cap bounds the work when webhook delivery has stalled. */
-const MAX_DIFF_COMMITS_FORWARD_PER_RUN = 10;
+ *  commits; this cap bounds the work when webhook delivery has stalled.
+ *  Sized so that (forward + backward) × per-commit fan-out stays well under the
+ *  Cloudflare Workers per-invocation subrequest limit (issue #124). */
+const MAX_DIFF_COMMITS_FORWARD_PER_RUN = 5;
 
 /** Maximum number of commits fetched in the backward (historical backfill) phase
  *  of the diff poller per repo per run.
  *  Backfill walks backward through repo history one hourly run at a time; the
  *  cap keeps per-run API and embedding cost bounded so the total sweep spreads
- *  over many runs (e.g. 10 commits/run × 24 runs/day = 240 commits/day). */
-const MAX_DIFF_COMMITS_BACKWARD_PER_RUN = 10;
+ *  over many runs (e.g. 5 commits/run × 24 runs/day = 120 commits/day per repo). */
+const MAX_DIFF_COMMITS_BACKWARD_PER_RUN = 5;
 
 /** Sentinel value indicating GitHub returned 304 Not Modified */
 const NOT_MODIFIED = Symbol("NOT_MODIFIED");


### PR DESCRIPTION
## Summary

`MAX_DIFF_COMMITS_FORWARD_PER_RUN` / `MAX_DIFF_COMMITS_BACKWARD_PER_RUN` を 10 → 5 に半減。PR #123 で diffs を独立 cron に分離後も per-commit fan-out で subrequest 上限に張り付いていたのを解消する。

Closes #124

## 背景

PR #123 deploy 後の初 diffs cron (2026-04-25 19:31 JST) で 15 errors:

```
pollDiffs: backward list failed for Liplus-Project/dipper_ai
pollDiffs: forward list failed for Liplus-Project/dipper_ai
pollDiffs: backward list failed for Liplus-Project/liplus-language
pollDiffs: forward list failed for Liplus-Project/liplus-language
pollDiffs: backward commit Liplus-Project/liplus-desktop@<sha> ... (複数)
```

各 commit detail = 1 GitHub fetch + N files × 3 internal subrequests (embed + Vectorize + D1 FTS)。20 commits × ~3 files × 3 = ~180/repo × 5 repos = ~900 + list 等で 1000 に張り付き、files/commit の変動と DO upsert 内部処理を加味して overshoot。

## 変更内容

`src/poller.ts` の 2 定数を 10 → 5 に変更。コメントの試算例も 10/run → 5/run に更新。

修正後の試算: ~225 subrequests / cron で 1000 上限に対し margin 大。

## トレードオフ

- backfill 速度: 5 commits/run × 24 runs/day × 5 repos = 600 commits/day（半減）
- 元設計が「段階的 backfill」のため仕様内
- 冪等性は `(repo, commit_sha, file_path)` PK upsert で担保、再開地点 overlap 安全

## Test plan

- [ ] CI / Workers Builds pass
- [ ] Deploy 後、次の `:30` diffs cron で `Too many subrequests` 新規発生なし
- [ ] light / comments cron は引き続きクリーン

## 本 PR 対象外（将来 issue）

- per-repo round-robin cron（POLL_REPOS が 10+ に増えた時の次手）
- per-run file count cap（極端に大きな commit が観測された時の次手）