### PR TITLE
refactor(tool): rename search_issues to search across all surfaces (patch)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -81,9 +81,9 @@ GitHub webhooks + GitHub API
 
 ## MCP Tools
 
-この MCP サーバーが公開するツールは 1 つに統合されています。意味検索、時系列 activity scan、doc 本文取得のいずれも `search_issues` のパラメータ経由で扱えます。以前の build で分かれていた `get_issue_context` / `get_doc_content` / `list_recent_activity` は削除され、用途は下記パラメータに吸収されました。
+この MCP サーバーが公開するツールは 1 つに統合されています。意味検索、時系列 activity scan、doc 本文取得のいずれも `search` のパラメータ経由で扱えます。以前の build で分かれていた `get_issue_context` / `get_doc_content` / `list_recent_activity` は削除され、用途は下記パラメータに吸収されました。
 
-### `search_issues`
+### `search`
 
 GitHub の issue / pull request / release / documentation / commit diff / comment 系 (issue と PR の top-level comment、PR review 本文、PR インラインレビューコメント) を対象にした統合検索ツールです。
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ See:
 
 ## MCP Tools
 
-This MCP server exposes a single consolidated tool. All retrieval modes — semantic search, time-ordered activity scan, and inline doc content fetch — are reached through `search_issues` via its parameter set. Earlier builds split these across `get_issue_context`, `get_doc_content`, and `list_recent_activity`; those tools have been removed and their use cases now fold into the parameters below.
+This MCP server exposes a single consolidated tool. All retrieval modes — semantic search, time-ordered activity scan, and inline doc content fetch — are reached through `search` via its parameter set. Earlier builds split these across `get_issue_context`, `get_doc_content`, and `list_recent_activity`; those tools have been removed and their use cases now fold into the parameters below.
 
-### `search_issues`
+### `search`
 
 Unified search across GitHub issues, pull requests, releases, repository documentation, commit diffs, and comment / review surfaces (top-level comments on issues and PRs, PR review bodies, and PR inline review comments).
 

--- a/docs/0-requirements.ja.md
+++ b/docs/0-requirements.ja.md
@@ -280,7 +280,7 @@ score(d) = sum_over_rankers ( 1 / (k + rank_r(d)) )
 
 ### 切替オプション
 
-`search_issues` の `fusion` パラメータで retrieval mode を切り替え可能:
+`search` の `fusion` パラメータで retrieval mode を切り替え可能:
 
 - `rrf` (default) — dense + sparse を RRF で合成
 - `dense_only` — Vectorize のみ（debug、semantic 特化クエリ）
@@ -295,7 +295,7 @@ score(d) = sum_over_rankers ( 1 / (k + rank_r(d)) )
 
 ## MCP Tools
 
-### `search_issues`
+### `search`
 
 Purpose:
 

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -280,13 +280,13 @@ Cost estimate:
 
 ### Fusion mode toggle
 
-`search_issues` accepts a `fusion` parameter:
+`search` accepts a `fusion` parameter:
 
 - `rrf` (default) — combine dense and sparse via RRF.
 - `dense_only` — query Vectorize only (debugging, semantic-heavy queries).
 - `sparse_only` — query D1 FTS5 BM25 only (debugging, exact-term / identifier queries).
 
-`search_issues` also accepts a `rerank` parameter:
+`search` also accepts a `rerank` parameter:
 
 - `true` (default) — re-score the RRF-fused candidates with bge-reranker-base.
 - `false` — skip rerank (faster, no Workers AI rerank cost; recommended for short-identifier queries where lexical match is already decisive, or for debugging).
@@ -295,7 +295,7 @@ The retrieval layer is intended to recover working state, not merely keyword mat
 
 ## MCP Tools
 
-### `search_issues`
+### `search`
 
 Purpose:
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -36,7 +36,7 @@ retrieval layer は **3-tier hybrid search**:
 
 ## MCP ツール
 
-### `search_issues`
+### `search`
 
 issue / pull request / release / documentation / **commit diff** を 3-tier hybrid search で引く。
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -86,9 +86,9 @@ Delete these files to force a fresh authorization flow.
 
 | Tool | Description |
 |---|---|
-| `search_issues` | 3-tier hybrid search (dense BGE-M3 + sparse BM25 + cross-encoder rerank) over issues, pull requests, releases, documentation, and commit diffs, with structured filters (`repo`, `state`, `labels`, `milestone`, `assignee`, `type`, `top_k`, `fusion`, `rerank`). |
+| `search` | 3-tier hybrid search (dense BGE-M3 + sparse BM25 + cross-encoder rerank) over issues, pull requests, releases, documentation, and commit diffs, with structured filters (`repo`, `state`, `labels`, `milestone`, `assignee`, `type`, `top_k`, `fusion`, `rerank`). |
 | `get_issue_context` | Aggregated state for a single issue or PR, including related PRs, branch, and CI status. |
-| `get_doc_content` | Fetch the raw content of a `.md` document from a tracked repository (use after `search_issues` with `type: "doc"`). |
+| `get_doc_content` | Fetch the raw content of a `.md` document from a tracked repository (use after `search` with `type: "doc"`). |
 | `list_recent_activity` | Recent created / updated / closed activity across tracked repositories. |
 
 All tools are read-only.

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,8 +3,8 @@
   "name": "github-rag-mcp",
   "display_name": "GitHub RAG MCP",
   "version": "0.1.0",
-  "description": "Semantic search for GitHub issues and PRs via Cloudflare Worker + Vectorize.",
-  "long_description": "GitHub RAG MCP is a memory-DB surface over GitHub project state: issues, PRs, releases, repository docs, commit diffs, issue/PR top-level comments, PR reviews, and PR inline review comments are indexed into Cloudflare Vectorize (BGE-M3 dense) + D1 FTS5 (BM25 sparse) and fused via RRF + cross-encoder rerank. A single consolidated tool (search_issues) handles hybrid semantic search, time-ordered activity scan, and inline doc content fetch, selected via its query / sort / include_content axes. Counterpart to github-webhook-mcp (push-based notifications) — together they give AI a complete view of GitHub project state.",
+  "description": "Hybrid semantic search across GitHub issues, PRs, releases, docs, commit diffs, and review threads via Cloudflare Worker + Vectorize.",
+  "long_description": "GitHub RAG MCP is a memory-DB surface over GitHub project state: issues, PRs, releases, repository docs, commit diffs, issue/PR top-level comments, PR reviews, and PR inline review comments are indexed into Cloudflare Vectorize (BGE-M3 dense) + D1 FTS5 (BM25 sparse) and fused via RRF + cross-encoder rerank. A single consolidated tool (search) handles hybrid semantic search, time-ordered activity scan, and inline doc content fetch, selected via its query / sort / include_content axes. Counterpart to github-webhook-mcp (push-based notifications) — together they give AI a complete view of GitHub project state.",
   "author": {
     "name": "Liplus Project",
     "url": "https://github.com/Liplus-Project"
@@ -41,7 +41,7 @@
   },
   "tools": [
     {
-      "name": "search_issues",
+      "name": "search",
       "description": "Unified search across GitHub issues, PRs, releases, docs, commit diffs, issue/PR top-level comments, PR reviews, and PR inline review comments. Three modes selected via query/sort axes: (1) hybrid semantic search (dense BGE-M3 + sparse BM25 fused via RRF + cross-encoder rerank), (2) time-ordered activity scan (empty query + sort), (3) doc content fetch (include_content=true inlines raw file content for top doc results). Structured filters: repo, state, labels, milestone, assignee, type."
     }
   ],

--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -7,7 +7,7 @@
  * Authenticates via OAuth 2.1 with PKCE (localhost callback).
  *
  * Tools are proxied to the Worker's MCP endpoint:
- *   search_issues — unified hybrid search / time-ordered activity scan /
+ *   search — unified hybrid search / time-ordered activity scan /
  *                   inline doc content fetch via Vectorize + Workers AI
  */
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -417,8 +417,8 @@ const server = new Server(
 
 const TOOLS = [
   {
-    name: "search_issues",
-    title: "Search Issues",
+    name: "search",
+    title: "Search GitHub",
     description:
       "Unified search across GitHub issues, PRs, releases, documentation, commit diffs, " +
       "issue/PR top-level comments, PR reviews, and PR inline review comments. Three modes: " +
@@ -525,7 +525,7 @@ const TOOLS = [
       },
     },
     annotations: {
-      title: "Search Issues",
+      title: "Search GitHub",
       readOnlyHint: true,
     },
   },

--- a/migrations/0002_fts5_rebuild.sql
+++ b/migrations/0002_fts5_rebuild.sql
@@ -3,7 +3,7 @@
 -- Layer = L4 Operations (sparse retrieval surface recovery)
 --
 -- Context:
---   Observed on 2026-04-24: `search_issues` sparse path and FTS upserts both
+--   Observed on 2026-04-24: `search` sparse path and FTS upserts both
 --   failed with `D1_ERROR: database disk image is malformed: SQLITE_CORRUPT
 --   (extended: SQLITE_CORRUPT_VTAB)`. The content-owner table `search_docs`
 --   was intact (1109 rows, direct bm25 queries via `wrangler d1 execute`

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
  *   POST /admin/reset-hashes?repo=owner/repo  -- Reset hashes and watermarks to trigger full re-embedding (requires GITHUB_TOKEN header)
  *
  * Durable Objects:
- *   RagMcpAgentV2  -- MCP server (tools: search_issues, get_issue_context, list_recent_activity)
+ *   RagMcpAgentV2  -- MCP server (tools: search, get_issue_context, list_recent_activity)
  *   IssueStore   -- Issue/PR state store (SQLite-backed)
  *
  * Cron Trigger:
@@ -41,7 +41,7 @@ export { IssueStore } from "./store.js";
 // Durable Object: MCP server — legacy stub (retained for migration compatibility only).
 export { RagMcpAgent } from "./mcp.js";
 
-// Durable Object: MCP server (tools: search_issues, get_issue_context, list_recent_activity)
+// Durable Object: MCP server (tools: search, get_issue_context, list_recent_activity)
 export { RagMcpAgentV2 } from "./mcp.js";
 
 // McpAgent.serve() returns a fetch handler for MCP protocol.

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -3,7 +3,7 @@
  * semantic search tool.
  *
  * Tools:
- *   search_issues — hybrid search + time-ordered activity scan + inline doc
+ *   search — hybrid search + time-ordered activity scan + inline doc
  *                    content fetch. Single entry point for GitHub issue / PR /
  *                    release / doc / commit-diff retrieval.
  *
@@ -103,9 +103,9 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
   }
 
   async init() {
-    // ── search_issues ──────────────────────────────────────────
+    // ── search ──────────────────────────────────────────
     this.server.tool(
-      "search_issues",
+      "search",
       "Unified search across GitHub issues, PRs, releases, repository documentation, commit diffs, " +
         "issue/PR top-level comments, PR reviews, and PR inline review comments. " +
         "Three modes via the query / sort axes:\n" +
@@ -695,7 +695,7 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
                   return await queryFts(this.env.DB_FTS, trimmedQuery, internalTopK, ftsFilter);
                 } catch (err) {
                   console.error(
-                    "search_issues: D1 FTS5 query failed:",
+                    "search: D1 FTS5 query failed:",
                     err instanceof Error ? err.message : String(err),
                   );
                   return [];


### PR DESCRIPTION
## 概要

統合検索ツールの命名を実態に合わせて修正する。`search_issues` → `search`、表示名 `Search Issues` → `Search GitHub`、関連 docs / manifest / コメント / エラーメッセージも全て同期。

過去に「search だけに変えて」要望があった際に「_issues」suffix が誤って残った経緯。今回完全 rename で解消。

## 変更内容

- 関数名: \`search_issues\` → \`search\`
- 表示名: \`Search Issues\` → \`Search GitHub\`
- .mcpb manifest description (broaden scope phrasing)
- Worker tool 登録 (\`src/mcp.ts\` L108) + local bridge dispatch (\`mcp-server/server/index.js\` L420)
- エラーメッセージ / コメント / 移行 SQL コメント / README / docs 全箇所

## 影響範囲

- 関数名変更は **breaking change**（AI / tool consumer の \`mcp__github-rag-mcp__search_issues\` 呼び出しは無効になる、新名 \`mcp__github-rag-mcp__search\` に切り替え必要）
- v0.x 初期開発期 (\`Anything may change\`) のため許容、patch 扱い
- データ schema (D1 / Vectorize / KV) には影響なし
- 既存 transcript / RAG index / docs 内の \`search_issues\` 表記は履歴として残るが、tool として callable な name は新名のみ

## テスト

\`mcp-server/npm test\` (= \`node --check server/index.js\`) syntax check pass。Worker 側に既存テストは無し、syntax check + 既存 CI に依存。

## バージョン

patch (v0.8.3 milestone)。v0.x 初期開発期で breaking 許容、scope は命名修正のみで実装ロジック変更なし。

## 関連

- Closes #126
- 過去要望: 「search だけに変えて」(時期不明) の補正