### PR TITLE
feat: index GitHub Wiki content into RAG (W4, patch)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 言語: [English](README.md) | 日本語
 
-Cloudflare Workers 上で動く、GitHub の issue / pull request / release / documentation 検索向け MCP サーバーです。
+Cloudflare Workers 上で動く、GitHub の issue / pull request / release / documentation / Wiki page / commit diff / comment 系 検索向け MCP サーバーです。
 
 `github-rag-mcp` は GitHub を AI の shared working memory として扱うために設計されています。会話を丸ごと保存して完全記憶を目指すのではなく、人間にも見える durable artifact から現在の状態を復元しやすくすることを重視します。
 
@@ -85,7 +85,7 @@ GitHub webhooks + GitHub API
 
 ### `search`
 
-GitHub の issue / pull request / release / documentation / commit diff / comment 系 (issue と PR の top-level comment、PR review 本文、PR インラインレビューコメント) を対象にした統合検索ツールです。
+GitHub の issue / pull request / release / documentation / **GitHub Wiki page** / commit diff / comment 系 (issue と PR の top-level comment、PR review 本文、PR インラインレビューコメント) を対象にした統合検索ツールです。
 
 `query` と `sort` の組み合わせで、以下の 3 モードを切り替えます。
 
@@ -123,7 +123,8 @@ bot (`sender.login` が `[bot]` で終わる) と trim 後 10 文字未満の bo
 | `"issue"` | GitHub issue (title + body)。 |
 | `"pull_request"` | pull request 本文 (title + body)。 |
 | `"release"` | release notes (name + body)。 |
-| `"doc"` | Markdown documentation。 |
+| `"doc"` | repo の Markdown documentation。 |
+| `"wiki_doc"` | GitHub Wiki page。`doc` とは別 surface で同名 page があれば両方検索結果に出る。 |
 | `"diff"` | commit の per-file diff (commit message + file path + patch)。 |
 | `"issue_comment"` | issue と PR の top-level コメント。 |
 | `"pr_review"` | PR レビュー本文 (`APPROVED` / `CHANGES_REQUESTED` / `COMMENTED`)。 |

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ This MCP server exposes a single consolidated tool. All retrieval modes — sema
 
 ### `search`
 
-Unified search across GitHub issues, pull requests, releases, repository documentation, commit diffs, and comment / review surfaces (top-level comments on issues and PRs, PR review bodies, and PR inline review comments).
+Unified search across GitHub issues, pull requests, releases, repository documentation, GitHub Wiki pages, commit diffs, and comment / review surfaces (top-level comments on issues and PRs, PR review bodies, and PR inline review comments).
 
 Three modes are selected by the combination of `query` and `sort`:
 
 1. **Hybrid semantic search (default)** — dense BGE-M3 over Vectorize + sparse BM25 over D1 FTS5, fused via Reciprocal Rank Fusion (RRF, k=60), then re-scored with the `@cf/baai/bge-reranker-base` cross-encoder. Pass a natural-language `query`.
 2. **Time-ordered activity scan** — omit or leave `query` empty and set `sort` to `"updated_desc"` or `"created_desc"`. Optionally narrow with `since` / `until` to list recent activity across every type. This subsumes the previous `list_recent_activity` tool.
-3. **Doc content fetch** — set `include_content: true`. For result rows whose `type` is `"doc"`, the raw file content is fetched from the GitHub contents API and inlined as a `content` field. Capped at the first few doc rows to bound API fan-out. This subsumes the previous `get_doc_content` tool.
+3. **Doc / wiki content fetch** — set `include_content: true`. For result rows whose `type` is `"doc"`, the raw file content is fetched from the GitHub contents API; for `type: "wiki_doc"` rows, the raw markup is fetched from `raw.githubusercontent.com/wiki/`. Both are inlined as a `content` field. Capped at the first few rows of each type to bound API fan-out. This subsumes the previous `get_doc_content` tool.
 
 Structured filters (`repo`, `state`, `labels`, `milestone`, `assignee`, `type`) apply in every mode.
 

--- a/docs/0-requirements.ja.md
+++ b/docs/0-requirements.ja.md
@@ -111,14 +111,15 @@ Responsibilities:
 
 - webhook 取りこぼしを補償する
 - 新しい repository の backfill を行う
-- issue、pull request、release、docs、issue/PR comments、commit diff の変更を再取得する
+- issue、pull request、release、docs、GitHub Wiki page、issue/PR comments、commit diff の変更を再取得する
 - 一時障害後も store を収束させる
 
-現在の deployment では hourly で 3 つの cron trigger に分けて実行する。各 upsert が Store DO + Vectorize + D1 FTS + AI embed と最大 4 internal fetch を生むため、heavy 同居 (comments + diffs) でも per-Worker subrequest 上限を超える。surface 単独単位で 15 分ずつずらして発火させる:
+現在の deployment では hourly で 4 つの cron trigger に分けて実行する。各 upsert が Store DO + Vectorize + D1 FTS + AI embed と最大 4 internal fetch を生むため、heavy 同居 (comments + diffs) でも per-Worker subrequest 上限を超える。surface 単独単位で 15 分ずつずらして発火させる:
 
 - **`0 * * * *` (light)** — issues / pull requests / releases / docs
 - **`15 * * * *` (comments)** — issue/PR comments のみ
 - **`30 * * * *` (diffs)** — commit diffs のみ
+- **`45 * * * *` (wiki)** — GitHub Wiki page のみ
 
 各 invocation は独立した subrequest 予算を持つ。dispatch は `controller.cron` で `handleScheduled` 内で行う。未知の cron 表現は no-op log で silent regression を防止する。
 
@@ -128,6 +129,14 @@ commit diff poller は 2-phase 構成:
 - **backward phase** — `until=oldestUnprocessedDate` で履歴を徐々に遡行する（新規 deployment や webhook 起動前の commit を backfill する経路）。watermark namespace は `diffs_backfill:${repo}`。
 
 1 run あたり上限は forward / backward それぞれ 10 commits。`processAndUpsertCommitDiff` の upsert は `(repo, commit_sha, file_path)` で idempotent なので、webhook / 両 phase 間で overlap しても副作用はない。
+
+wiki poller は `:45` cron 専属で、GitHub Wiki content の唯一の取り込み経路。Wiki は別 git repo (`{repo}.wiki.git`) に存在し、REST API も webhook event も持たないため、poller が repo ごとに 3 段の HTTP 呼び出しで処理する:
+
+1. `https://github.com/{repo}.wiki.git/info/refs?service=git-upload-pack` を打って wiki 存在検出（200 = 存在、404 = 無効化済 or 未設置 = skip）。
+2. `/{repo}/wiki/_pages` HTML を scrape して page slug を列挙（`/{repo}/wiki/{slug}` 形式の link を tolerant な regex で拾う、`_pages` / `_history` / `_new` 等の特殊 pseudo-page は除外）。
+3. 各 slug について `https://raw.githubusercontent.com/wiki/{repo}/master/{slug}.{ext}` から raw markup を取得。markup 拡張子は probe 順 (`md` → `markdown` → `mediawiki` → `org` → `rst` → `rest` → `textile` → `pod` → `asciidoc` → `creole`) で検出、次回以降は前回ヒット拡張子を再利用して probe を省略。
+
+変更検出は SHA-256 content hash（wiki git smart-HTTP を叩かないと git blob SHA は取れないため、content 直接 hash）。hash 差分のある page だけ re-embed、`_pages` index に消えた page は Vectorize / D1 FTS5 / structured store から削除。1 cron run あたりの per-repo 上限は `MAX_WIKI_EMBEDDINGS_PER_RUN`（既定 30）で、初回 bulk import が複数 cron に分散する。
 
 ### 4. Embedding Pipeline
 
@@ -213,7 +222,8 @@ Durable Object + SQLite は次の structured record を保持する。
 
 - issue / pull request
 - release
-- documentation file state
+- documentation file state（repo `docs/` 等の `.md` ファイル）
+- GitHub Wiki page state（page slug、拡張子、content hash）
 - commit diff file state（1 row = 1 file-in-commit）
 - polling watermark
 

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -111,14 +111,15 @@ Responsibilities:
 
 - repair missed webhook deliveries
 - backfill new repositories
-- refresh changed issues, pull requests, releases, docs, issue/PR comments, and commit diffs
+- refresh changed issues, pull requests, releases, docs, GitHub Wiki pages, issue/PR comments, and commit diffs
 - keep the stores converged even after transient failures
 
-The poller runs hourly in the current deployment, split across three cron triggers so each invocation gets its own Cloudflare Workers subrequest budget. Each upsert fans out to Store DO + Vectorize + D1 FTS + AI embed (up to four internal subrequests), so even the comments + diffs combination overshoots the per-Worker ceiling on busy repositories; the heavy surfaces run one-per-cron, staggered by 15 minutes:
+The poller runs hourly in the current deployment, split across four cron triggers so each invocation gets its own Cloudflare Workers subrequest budget. Each upsert fans out to Store DO + Vectorize + D1 FTS + AI embed (up to four internal subrequests), so even the comments + diffs combination overshoots the per-Worker ceiling on busy repositories; the heavy surfaces run one-per-cron, staggered by 15 minutes:
 
 - **`0 * * * *` (light)** — issues, pull requests, releases, docs
 - **`15 * * * *` (comments)** — issue / PR comments only
 - **`30 * * * *` (diffs)** — commit diffs only
+- **`45 * * * *` (wiki)** — GitHub Wiki pages only
 
 Dispatch is performed inside `handleScheduled` by inspecting `controller.cron`. Unknown cron expressions fall through to a no-op log to prevent silent regressions when triggers are added later.
 
@@ -128,6 +129,14 @@ The commit-diff poller runs in two phases:
 - **backward phase** — walks backward through history using `until=oldestUnprocessedDate`, backfilling commits that predate the webhook or a fresh deployment. Watermark namespace: `diffs_backfill:${repo}`.
 
 Each phase is capped at 10 commits per repo per run. Upserts through `processAndUpsertCommitDiff` are idempotent on `(repo, commit_sha, file_path)`, so overlap between webhook and either phase is safe.
+
+The wiki poller runs in the `:45` cron and is the only ingestion path for GitHub Wiki content. Wiki pages live in a separate git repo (`{repo}.wiki.git`) that GitHub does not expose through the REST API or webhook events; the poller therefore performs three lightweight HTTP calls per repo:
+
+1. Probe `https://github.com/{repo}.wiki.git/info/refs?service=git-upload-pack` to detect whether the wiki exists (200 = present, 404 = disabled or absent — skip the rest).
+2. Scrape the public `/{repo}/wiki/_pages` HTML index for page slugs (the link href shape `/{repo}/wiki/{slug}` is stable enough for a tolerant regex; underscore-prefixed pseudo-pages like `_pages` / `_history` / `_new` are filtered out).
+3. For each slug, fetch the raw markup body from `https://raw.githubusercontent.com/wiki/{repo}/master/{slug}.{ext}`. Markup extension is detected via probe order (`md` → `markdown` → `mediawiki` → `org` → `rst` → `rest` → `textile` → `pod` → `asciidoc` → `creole`); subsequent polls reuse the previously found extension to skip the probe.
+
+Change detection uses a content SHA-256 hash (no git blob SHA is available without invoking the wiki git smart-HTTP protocol). Pages whose hash differs from the stored value are re-embedded; pages absent from the current `_pages` index but present in the store are deleted from Vectorize, D1 FTS5, and the structured state store. Per-repo wiki embedding is capped (`MAX_WIKI_EMBEDDINGS_PER_RUN`, default 30) so a one-time bulk import spreads across multiple cron runs.
 
 ### 4. Embedding Pipeline
 
@@ -159,14 +168,15 @@ Responsibilities:
 Vectorize is the dense side of hybrid retrieval. It stores semantic embeddings and metadata for:
 
 - repository
-- item type (`issue` / `pull_request` / `release` / `doc` / `diff`)
+- item type (`issue` / `pull_request` / `release` / `doc` / `wiki_doc` / `diff` / `issue_comment` / `pr_review` / `pr_review_comment`)
 - state
 - labels (individual slots label_0..3 + CSV fallback)
 - milestone
 - assignees (individual slots assignee_0..1 + CSV fallback)
 - update timestamp
 - release tag name
-- documentation path
+- documentation path (doc rows)
+- wiki page slug + extension (wiki_doc rows)
 - commit SHA, file path, file status, commit date, commit author, blob SHA (diff only)
 
 Metadata indexes (10/10 slots used):
@@ -191,7 +201,7 @@ Rationale:
 Schema overview:
 
 - `search_docs` — external content table (source of truth, `vector_id` primary key).
-- `search_docs_nat_fts` — FTS5 virtual table with porter + unicode61 tokenizer for natural-language surfaces (issue / PR / release / doc).
+- `search_docs_nat_fts` — FTS5 virtual table with porter + unicode61 tokenizer for natural-language surfaces (issue / PR / release / doc / wiki_doc / comment / review surfaces).
 - `search_docs_code_fts` — FTS5 virtual table with trigram tokenizer for code / SHA / identifier surfaces (diff).
 
 Tokenizer selection:
@@ -213,7 +223,8 @@ Durable Object with SQLite stores structured records for:
 
 - issues and pull requests
 - releases
-- documentation file state
+- documentation file state (repo `docs/` and other tracked `.md`)
+- GitHub Wiki page state (page slug, extension, content hash)
 - commit diff file state (one row per file-in-commit)
 - polling watermarks
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,6 +1,6 @@
 # github-rag-mcp
 
-Stdio MCP proxy that bridges local MCP clients (Claude Desktop, Claude Code, etc.) to a remote [github-rag-mcp](https://github.com/Liplus-Project/github-rag-mcp) Cloudflare Worker for semantic and structured search over GitHub issues, pull requests, releases, documentation, and commit diffs.
+Stdio MCP proxy that bridges local MCP clients (Claude Desktop, Claude Code, etc.) to a remote [github-rag-mcp](https://github.com/Liplus-Project/github-rag-mcp) Cloudflare Worker for semantic and structured search over GitHub issues, pull requests, releases, documentation, GitHub Wiki pages, and commit diffs.
 
 This package is the **client-side proxy only**. The actual indexing pipeline (Vectorize + D1 FTS5 + Workers AI BGE-M3 + cross-encoder rerank) runs on the Worker. See the [main repository](https://github.com/Liplus-Project/github-rag-mcp) for architecture and self-hosting instructions.
 
@@ -86,7 +86,7 @@ Delete these files to force a fresh authorization flow.
 
 | Tool | Description |
 |---|---|
-| `search` | 3-tier hybrid search (dense BGE-M3 + sparse BM25 + cross-encoder rerank) over issues, pull requests, releases, documentation, and commit diffs, with structured filters (`repo`, `state`, `labels`, `milestone`, `assignee`, `type`, `top_k`, `fusion`, `rerank`). |
+| `search` | 3-tier hybrid search (dense BGE-M3 + sparse BM25 + cross-encoder rerank) over issues, pull requests, releases, documentation, **GitHub Wiki pages**, and commit diffs, with structured filters (`repo`, `state`, `labels`, `milestone`, `assignee`, `type`, `top_k`, `fusion`, `rerank`). |
 | `get_issue_context` | Aggregated state for a single issue or PR, including related PRs, branch, and CI status. |
 | `get_doc_content` | Fetch the raw content of a `.md` document from a tracked repository (use after `search` with `type: "doc"`). |
 | `list_recent_activity` | Recent created / updated / closed activity across tracked repositories. |

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,8 +3,8 @@
   "name": "github-rag-mcp",
   "display_name": "GitHub RAG MCP",
   "version": "0.1.0",
-  "description": "Hybrid semantic search across GitHub issues, PRs, releases, docs, commit diffs, and review threads via Cloudflare Worker + Vectorize.",
-  "long_description": "GitHub RAG MCP is a memory-DB surface over GitHub project state: issues, PRs, releases, repository docs, commit diffs, issue/PR top-level comments, PR reviews, and PR inline review comments are indexed into Cloudflare Vectorize (BGE-M3 dense) + D1 FTS5 (BM25 sparse) and fused via RRF + cross-encoder rerank. A single consolidated tool (search) handles hybrid semantic search, time-ordered activity scan, and inline doc content fetch, selected via its query / sort / include_content axes. Counterpart to github-webhook-mcp (push-based notifications) — together they give AI a complete view of GitHub project state.",
+  "description": "Hybrid semantic search across GitHub issues, PRs, releases, docs, GitHub Wiki pages, commit diffs, and review threads via Cloudflare Worker + Vectorize.",
+  "long_description": "GitHub RAG MCP is a memory-DB surface over GitHub project state: issues, PRs, releases, repository docs, GitHub Wiki pages, commit diffs, issue/PR top-level comments, PR reviews, and PR inline review comments are indexed into Cloudflare Vectorize (BGE-M3 dense) + D1 FTS5 (BM25 sparse) and fused via RRF + cross-encoder rerank. A single consolidated tool (search) handles hybrid semantic search, time-ordered activity scan, and inline doc / wiki content fetch, selected via its query / sort / include_content axes. Counterpart to github-webhook-mcp (push-based notifications) — together they give AI a complete view of GitHub project state.",
   "author": {
     "name": "Liplus Project",
     "url": "https://github.com/Liplus-Project"
@@ -42,7 +42,7 @@
   "tools": [
     {
       "name": "search",
-      "description": "Unified search across GitHub issues, PRs, releases, docs, commit diffs, issue/PR top-level comments, PR reviews, and PR inline review comments. Three modes selected via query/sort axes: (1) hybrid semantic search (dense BGE-M3 + sparse BM25 fused via RRF + cross-encoder rerank), (2) time-ordered activity scan (empty query + sort), (3) doc content fetch (include_content=true inlines raw file content for top doc results). Structured filters: repo, state, labels, milestone, assignee, type."
+      "description": "Unified search across GitHub issues, PRs, releases, docs, GitHub Wiki pages, commit diffs, issue/PR top-level comments, PR reviews, and PR inline review comments. Three modes selected via query/sort axes: (1) hybrid semantic search (dense BGE-M3 + sparse BM25 fused via RRF + cross-encoder rerank), (2) time-ordered activity scan (empty query + sort), (3) doc/wiki content fetch (include_content=true inlines raw markup for top doc and wiki_doc results). Structured filters: repo, state, labels, milestone, assignee, type (issue / pull_request / release / doc / wiki_doc / diff / issue_comment / pr_review / pr_review_comment)."
     }
   ],
   "compatibility": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@
  *
  * Durable Objects:
  *   RagMcpAgentV2  -- MCP server (tools: search, get_issue_context, list_recent_activity)
- *   IssueStore   -- Issue/PR state store (SQLite-backed)
+ *   IssueStore   -- Issue/PR/wiki state store (SQLite-backed)
  *
  * Cron Trigger:
  *   Hourly (fallback) -- poll GitHub API for issue/PR updates, generate embeddings, upsert vectors

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -21,6 +21,7 @@ import type {
   IssueRecord,
   ReleaseRecord,
   DocRecord,
+  WikiDocRecord,
   DiffRecord,
   IssueCommentRecord,
   PRReviewRecord,
@@ -106,17 +107,19 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
     // ── search ──────────────────────────────────────────
     this.server.tool(
       "search",
-      "Unified search across GitHub issues, PRs, releases, repository documentation, commit diffs, " +
-        "issue/PR top-level comments, PR reviews, and PR inline review comments. " +
+      "Unified search across GitHub issues, PRs, releases, repository documentation, GitHub Wiki pages, " +
+        "commit diffs, issue/PR top-level comments, PR reviews, and PR inline review comments. " +
         "Three modes via the query / sort axes:\n" +
         "  1. Hybrid semantic search (default): dense BGE-M3 over Vectorize + sparse BM25 over D1 FTS5, " +
         "fused via Reciprocal Rank Fusion (RRF, k=60), then re-scored with a cross-encoder " +
         "(@cf/baai/bge-reranker-base; set rerank: false to skip).\n" +
         "  2. Time-ordered activity scan: pass an empty (or omitted) query with sort=\"updated_desc\" or \"created_desc\"; " +
         "optionally narrow via since / until to list recent activity across every type.\n" +
-        "  3. Doc content fetch: pass include_content: true to inline the raw file content of top doc results " +
-        "(fetched from the GitHub contents API; capped at the first few doc rows).\n" +
+        "  3. Doc content fetch: pass include_content: true to inline the raw file content of top doc and wiki_doc results " +
+        "(docs via GitHub Contents API, wiki_docs via raw.githubusercontent.com/wiki; capped at the first few rows of each).\n" +
         "Optional metadata filters (repo, state, labels, milestone, assignee, type) apply across all modes. " +
+        "Use type: \"doc\" for repository docs (files in /docs/ etc.) and type: \"wiki_doc\" for GitHub Wiki pages — " +
+        "both surfaces co-exist and a same-name page in both is returned as two separate hits. " +
         "Use type: \"diff\" to retrieve judgment history preserved in commit diffs — including changes to deleted files " +
         "and non-.md files that are not present in the live document index. " +
         "Use type: \"issue_comment\" / \"pr_review\" / \"pr_review_comment\" to retrieve comment-level judgment history " +
@@ -157,6 +160,7 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
             "pull_request",
             "release",
             "doc",
+            "wiki_doc",
             "diff",
             "issue_comment",
             "pr_review",
@@ -167,6 +171,8 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
           .default("all")
           .describe(
             "Filter by type (default: all). " +
+              "\"doc\" = repository docs (files in /docs/ etc.). " +
+              "\"wiki_doc\" = GitHub Wiki pages (separate from repo docs; both surfaces co-exist). " +
               "\"diff\" = per-file commit diffs. " +
               "\"issue_comment\" = top-level comments on issues and PRs. " +
               "\"pr_review\" = PR review bodies (approve / request_changes / comment). " +
@@ -285,6 +291,7 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
               | "pull_request"
               | "release"
               | "doc"
+              | "wiki_doc"
               | "diff"
               | "issue_comment"
               | "pr_review"
@@ -302,6 +309,10 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
             tag_name?: string;
             prerelease?: boolean;
             doc_path?: string;
+            /** Wiki page slug (wiki_doc rows only) */
+            wiki_path?: string;
+            /** Wiki page extension (wiki_doc rows only, e.g. "md", "org") */
+            wiki_extension?: string;
             commit_sha?: string;
             file_path?: string;
             file_status?: string;
@@ -408,6 +419,39 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
                     updated_at: d.updatedAt,
                     created_at: d.updatedAt,
                     doc_path: d.path,
+                  });
+                }
+              }
+            } catch {
+              // Non-critical.
+            }
+          }
+
+          // Wiki docs
+          if (wantType("wiki_doc")) {
+            try {
+              const res = await store.fetch(
+                new Request(
+                  `http://store/recent-wiki-docs?${buildParams().toString()}`,
+                ),
+              );
+              if (res.ok) {
+                const records = (await res.json()) as WikiDocRecord[];
+                for (const w of records) {
+                  rows.push({
+                    type: "wiki_doc",
+                    repo: w.repo,
+                    number: 0,
+                    title: w.pageName,
+                    state: "active",
+                    labels: [],
+                    milestone: "",
+                    assignees: [],
+                    url: `https://github.com/${w.repo}/wiki/${encodeURIComponent(w.pageName)}`,
+                    updated_at: w.updatedAt,
+                    created_at: w.updatedAt,
+                    wiki_path: w.pageName,
+                    wiki_extension: w.extension,
                   });
                 }
               }
@@ -949,6 +993,8 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
           repo: string;
           tag_name?: string;
           doc_path?: string;
+          wiki_path?: string;
+          wiki_extension?: string;
           commit_sha?: string;
           file_path?: string;
           file_status?: string;
@@ -976,6 +1022,13 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
           const updatedAt = meta?.updated_at ?? ftsRow?.updatedAt ?? "";
           const tagName = meta?.tag_name ?? ftsRow?.tagName ?? "";
           const docPath = meta?.doc_path ?? ftsRow?.docPath ?? "";
+          // wiki_doc rows reuse the FTS5 `doc_path` column for the page slug —
+          // the schema-level field is unified across "where did this come from",
+          // distinguished by the row's `type`. Vectorize metadata carries the
+          // dedicated `wiki_path` / `wiki_extension` fields so we prefer them
+          // when present and fall back to the FTS row when the dense hit lost.
+          const wikiPath = (meta?.wiki_path as string | undefined) ?? (itemType === "wiki_doc" ? ftsRow?.docPath ?? "" : "");
+          const wikiExtension = (meta?.wiki_extension as string | undefined) ?? "";
           const commitSha = meta?.commit_sha ?? ftsRow?.commitSha ?? "";
           const filePath = meta?.file_path ?? ftsRow?.filePath ?? "";
           const fileStatus = meta?.file_status ?? ftsRow?.fileStatus ?? "";
@@ -991,6 +1044,8 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
             url = `https://github.com/${itemRepo}/releases/tag/${tagName}`;
           } else if (itemType === "doc" && docPath) {
             url = `https://github.com/${itemRepo}/blob/main/${docPath}`;
+          } else if (itemType === "wiki_doc" && wikiPath) {
+            url = `https://github.com/${itemRepo}/wiki/${encodeURIComponent(wikiPath)}`;
           } else if (itemType === "diff" && commitSha) {
             url = `https://github.com/${itemRepo}/commit/${commitSha}`;
           } else if (itemType === "issue_comment" && commentId) {
@@ -1024,6 +1079,12 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
             repo: itemRepo,
             ...(itemType === "release" ? { tag_name: tagName } : {}),
             ...(itemType === "doc" ? { doc_path: docPath } : {}),
+            ...(itemType === "wiki_doc"
+              ? {
+                  wiki_path: wikiPath,
+                  ...(wikiExtension ? { wiki_extension: wikiExtension } : {}),
+                }
+              : {}),
             ...(itemType === "diff"
               ? {
                   commit_sha: commitSha,
@@ -1077,6 +1138,10 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
           } else if (item.type === "doc" && item.repo && item.doc_path) {
             // Use the file path as the title for docs
             item.title = item.doc_path;
+          } else if (item.type === "wiki_doc" && item.repo && item.wiki_path) {
+            // Wiki page slug serves as the title; the row's url already points
+            // at the rendered wiki page so the slug is sufficient context.
+            item.title = item.wiki_path;
           } else if (item.type === "diff") {
             // Title = "{short-sha} {file_path}" so the result list remains
             // scannable without making an additional API call.
@@ -1158,30 +1223,42 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
   }
 
   /**
-   * Inline raw file content on up to INCLUDE_CONTENT_MAX_DOCS doc rows.
-   * Mutates the rows in place (adds a `content` field). Non-doc rows and
-   * rows beyond the cap are left untouched.
+   * Inline raw file content on up to INCLUDE_CONTENT_MAX_DOCS doc / wiki_doc rows.
+   * Mutates the rows in place (adds a `content` field). Non-doc rows and rows
+   * beyond the cap are left untouched.
    *
-   * Scope note: top-N doc fetch is a fan-out bound for GitHub contents API.
-   * Callers needing more doc bodies should page by repeating the search.
+   * Doc rows are fetched via the GitHub Contents REST API (authenticated).
+   * Wiki_doc rows are fetched from `raw.githubusercontent.com/wiki/...` —
+   * GitHub does not expose wiki content through REST, so the public raw URL
+   * is the only path. Both branches share the same INCLUDE_CONTENT_MAX_DOCS
+   * cap since they target the same surface (rendered documentation) from the
+   * caller's perspective.
+   *
+   * Scope note: top-N doc fetch is a fan-out bound. Callers needing more
+   * bodies should page by repeating the search.
    */
   private async inlineDocContent<
     T extends {
       type: string;
       repo?: string;
       doc_path?: string;
+      wiki_path?: string;
+      wiki_extension?: string;
       content?: string;
     },
   >(rows: T[], fallbackRepo?: string): Promise<void> {
     const docRows = rows.filter((r) => r.type === "doc");
-    if (docRows.length === 0) return;
-    const toFetch = docRows.slice(0, INCLUDE_CONTENT_MAX_DOCS);
+    const wikiRows = rows.filter((r) => r.type === "wiki_doc");
+    if (docRows.length === 0 && wikiRows.length === 0) return;
+
+    const docToFetch = docRows.slice(0, INCLUDE_CONTENT_MAX_DOCS);
+    const wikiToFetch = wikiRows.slice(0, INCLUDE_CONTENT_MAX_DOCS);
 
     const token = this.getGitHubToken();
     const headers = githubHeaders(token);
 
-    await Promise.all(
-      toFetch.map(async (row) => {
+    await Promise.all([
+      ...docToFetch.map(async (row) => {
         const docPath = row.doc_path;
         const itemRepo = row.repo ?? fallbackRepo ?? "";
         if (!docPath || !itemRepo) return;
@@ -1194,7 +1271,6 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
             encoding?: string;
           };
           if (!data.content) return;
-          // GitHub returns base64-encoded content; decode via Uint8Array for UTF-8 safety.
           const binary = atob(data.content.replace(/\n/g, ""));
           const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
           row.content = new TextDecoder().decode(bytes);
@@ -1202,6 +1278,22 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
           // Best-effort inline; a failed fetch leaves `content` unset.
         }
       }),
-    );
+      ...wikiToFetch.map(async (row) => {
+        const pageName = row.wiki_path;
+        const itemRepo = row.repo ?? fallbackRepo ?? "";
+        const ext = row.wiki_extension || "md";
+        if (!pageName || !itemRepo) return;
+        const url = `https://raw.githubusercontent.com/wiki/${itemRepo}/master/${encodeURIComponent(pageName)}.${ext}`;
+        try {
+          const res = await fetch(url, {
+            headers: { "User-Agent": "github-rag-mcp/0.1.0" },
+          });
+          if (!res.ok) return;
+          row.content = await res.text();
+        } catch {
+          // Best-effort inline; a failed fetch leaves `content` unset.
+        }
+      }),
+    ]);
   }
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -11,6 +11,7 @@ import type {
   IssueRecord,
   ReleaseRecord,
   DocRecord,
+  WikiDocRecord,
   DiffRecord,
   DiffFileStatus,
   IssueCommentRecord,
@@ -229,6 +230,15 @@ export function releaseVectorId(
  */
 export function docVectorId(repo: string, path: string): Promise<string> {
   return stableVectorId("d", repo, path);
+}
+
+/**
+ * Build Vectorize vector ID for a wiki page.
+ * Deterministic SHA-256-based ID under the "w" prefix.
+ * Wiki page names are URL slugs (dash-separated), unique within a repo's wiki.
+ */
+export function wikiDocVectorId(repo: string, pageName: string): Promise<string> {
+  return stableVectorId("w", repo, pageName);
 }
 
 /**
@@ -803,6 +813,125 @@ export async function processAndUpsertDoc(
   } catch (err) {
     console.error(
       `Failed to embed doc ${repo}/${path}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return { embedded: false, skippedUnchanged: false, metadataUpdated: false, failed: true };
+  }
+}
+
+// ── Wiki doc surface ─────────────────────────────────────────
+
+/**
+ * Compute SHA-256 over UTF-8 bytes of the wiki content. Used as the change
+ * detection signal in lieu of git blob SHAs (the wiki git protocol is not
+ * exposed via REST, so we hash content directly).
+ */
+export async function sha256Hex(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(text);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return hex;
+}
+
+/**
+ * Embed and upsert a single wiki page.
+ *
+ * Mirrors `processAndUpsertDoc` but writes vector / FTS / store records under
+ * the `wiki_doc` type. Vector ID prefix `"w:"` keeps wiki rows in their own
+ * namespace so they never collide with repo doc rows even when page name and
+ * doc path coincide.
+ *
+ * @param env         Worker env bindings (AI, VECTORIZE, DB_FTS)
+ * @param storeStub   Durable Object stub for IssueStore
+ * @param repo        Repository in "owner/repo" format (the wiki belongs to {repo}.wiki)
+ * @param pageName    GitHub Wiki page slug (dash-separated, e.g., "Home" or "Foo-Bar")
+ * @param extension   Markup file extension that serves the page (e.g., "md", "markdown", "org")
+ * @param content     Raw markup content fetched from raw.githubusercontent.com/wiki
+ * @returns UpsertResult indicating what happened
+ */
+export async function processAndUpsertWikiDoc(
+  env: Env,
+  storeStub: DurableObjectStub,
+  repo: string,
+  pageName: string,
+  extension: string,
+  content: string,
+): Promise<UpsertResult> {
+  const now = new Date().toISOString();
+
+  try {
+    // Generate embedding (use page name as title surrogate, content as body)
+    const embeddingInput = prepareEmbeddingInput(pageName, content);
+    const embedding = await generateEmbedding(env.AI, embeddingInput);
+
+    const metadata: Record<string, string | number> = {
+      repo,
+      number: 0,
+      type: "wiki_doc",
+      state: "active",
+      labels: "",
+      milestone: "",
+      assignees: "",
+      updated_at: now,
+      wiki_path: pageName,
+      wiki_extension: extension,
+    };
+
+    const wvid = await wikiDocVectorId(repo, pageName);
+    await env.VECTORIZE.upsert([
+      {
+        id: wvid,
+        values: embedding,
+        metadata,
+      },
+    ]);
+
+    // Mirror into D1 FTS5. We reuse the existing `doc_path` column to store
+    // the wiki page slug — semantically the same kind of "where did this come
+    // from" field, distinguished by the row's `type='wiki_doc'`.
+    try {
+      await upsertFtsRow(env.DB_FTS, {
+        vectorId: wvid,
+        repo,
+        type: "wiki_doc",
+        state: "active",
+        labels: "",
+        milestone: "",
+        assignees: "",
+        updatedAt: now,
+        docPath: pageName,
+        content: embeddingInput,
+      });
+    } catch (ftsErr) {
+      console.error(
+        `Failed to upsert FTS5 row for wiki ${repo}/${pageName}:`,
+        ftsErr instanceof Error ? ftsErr.message : String(ftsErr),
+      );
+    }
+
+    const contentHash = await sha256Hex(content);
+    const record: WikiDocRecord = {
+      repo,
+      pageName,
+      extension,
+      contentHash,
+      updatedAt: now,
+    };
+
+    await storeStub.fetch(
+      new Request("http://store/upsert-wiki-doc", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(record),
+      }),
+    );
+
+    return { embedded: true, skippedUnchanged: false, metadataUpdated: false, failed: false };
+  } catch (err) {
+    console.error(
+      `Failed to embed wiki doc ${repo}/${pageName}:`,
       err instanceof Error ? err.message : String(err),
     );
     return { embedded: false, skippedUnchanged: false, metadataUpdated: false, failed: true };

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -7,17 +7,26 @@
  * Stores structured metadata in IssueStore Durable Object.
  */
 
-import type { Env, IssueRecord, ReleaseRecord, DocRecord } from "./types.js";
+import type {
+  Env,
+  IssueRecord,
+  ReleaseRecord,
+  DocRecord,
+  WikiDocRecord,
+} from "./types.js";
 import {
   docVectorId,
+  wikiDocVectorId,
   processAndUpsertIssue,
   processAndUpsertRelease,
   processAndUpsertDoc,
+  processAndUpsertWikiDoc,
   processAndUpsertCommitDiff,
   fetchCommitDetail,
   ingestIssueComment,
   ingestPRReview,
   ingestPRReviewComment,
+  sha256Hex,
   type GitHubIssueData,
   type GitHubReleaseData,
   type GitHubCommentData,
@@ -776,6 +785,268 @@ async function pollDocs(
   );
 }
 
+// ── Wiki doc poller ──────────────────────────────────────────
+
+/**
+ * Wiki page markup file extensions that GitHub Wiki natively supports
+ * (https://github.com/gollum/gollum). Sorted by popularity so the first hit
+ * on a fresh page is usually the first probe.
+ */
+const WIKI_EXTENSIONS = [
+  "md",
+  "markdown",
+  "mediawiki",
+  "org",
+  "rst",
+  "rest",
+  "textile",
+  "pod",
+  "asciidoc",
+  "creole",
+] as const;
+
+/** Maximum wiki pages embedded per repo per cron run.
+ *  Caps Workers AI embed budget the same way MAX_EMBEDDINGS_PER_RUN does for
+ *  repository docs. Remaining changed pages are picked up on the next cron. */
+const MAX_WIKI_EMBEDDINGS_PER_RUN = 30;
+
+/**
+ * Probe whether a repo has a wiki at all.
+ *
+ * GitHub does not expose wiki content through the REST API, but the wiki git
+ * repo is publicly addressable at `https://github.com/{repo}.wiki.git`. The
+ * git smart-HTTP discovery endpoint returns 200 when the wiki exists and 404
+ * when it does not (or wiki is disabled for the repo). This costs one HTTP
+ * round-trip per repo per poll without parsing any git protocol bytes.
+ */
+async function wikiExists(repo: string): Promise<boolean> {
+  const url = `https://github.com/${repo}.wiki.git/info/refs?service=git-upload-pack`;
+  try {
+    const resp = await fetch(url, {
+      method: "GET",
+      redirect: "follow",
+      headers: { "User-Agent": "github-rag-mcp/0.1.0" },
+    });
+    return resp.status === 200;
+  } catch (err) {
+    console.error(
+      `wikiExists probe failed for ${repo}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return false;
+  }
+}
+
+/**
+ * Enumerate wiki page slugs by scraping the `/{repo}/wiki/_pages` HTML index.
+ *
+ * GitHub renders this page as a flat list of every wiki page, with each link
+ * shaped `<a ... href="/{repo}/wiki/{page-slug}">`. We extract the slugs with
+ * a tolerant regex and reject the special pseudo-pages (`_pages`, `_history`,
+ * `_new`, `_access`, etc.) that share the underscore prefix convention.
+ *
+ * If the index is empty or the request fails, we return [] so the caller can
+ * fall through to the no-op path.
+ */
+async function listWikiPages(repo: string): Promise<string[]> {
+  const url = `https://github.com/${repo}/wiki/_pages`;
+  try {
+    const resp = await fetch(url, {
+      headers: {
+        Accept: "text/html",
+        "User-Agent": "github-rag-mcp/0.1.0",
+      },
+    });
+    if (!resp.ok) {
+      return [];
+    }
+    const html = await resp.text();
+    // Match `href="/{repo}/wiki/PageName"` — capture the page slug. Both the
+    // repo and the slug may contain dots, dashes, and percent-escapes that we
+    // unwrap with decodeURIComponent below. The character class excludes URL
+    // delimiters that would terminate the slug naturally.
+    const escapedRepo = repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`href="/${escapedRepo}/wiki/([^"#?]+)"`, "g");
+    const pages = new Set<string>();
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(html)) !== null) {
+      let slug: string;
+      try {
+        slug = decodeURIComponent(m[1]);
+      } catch {
+        slug = m[1];
+      }
+      if (!slug || slug.startsWith("_")) continue;
+      pages.add(slug);
+    }
+    return Array.from(pages);
+  } catch (err) {
+    console.error(
+      `listWikiPages failed for ${repo}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return [];
+  }
+}
+
+/**
+ * Fetch a wiki page's raw markup content.
+ *
+ * GitHub serves wiki content from `raw.githubusercontent.com/wiki/{repo}/master/{page}.{ext}`.
+ * If `preferredExtension` is provided (i.e. the page is already known from a
+ * previous poll), try it first to skip the multi-extension probe. Otherwise
+ * iterate through every supported extension until one returns 200.
+ *
+ * Returns null when no extension matches (page may have been deleted, renamed,
+ * or moved to an unsupported format).
+ */
+async function fetchWikiContent(
+  repo: string,
+  pageName: string,
+  preferredExtension?: string,
+): Promise<{ content: string; extension: string } | null> {
+  const probes = preferredExtension
+    ? [preferredExtension, ...WIKI_EXTENSIONS.filter((e) => e !== preferredExtension)]
+    : Array.from(WIKI_EXTENSIONS);
+
+  for (const ext of probes) {
+    const url = `https://raw.githubusercontent.com/wiki/${repo}/master/${encodeURIComponent(pageName)}.${ext}`;
+    try {
+      const resp = await fetch(url, {
+        headers: { "User-Agent": "github-rag-mcp/0.1.0" },
+      });
+      if (resp.ok) {
+        return { content: await resp.text(), extension: ext };
+      }
+    } catch (err) {
+      console.error(
+        `fetchWikiContent probe ${ext} failed for ${repo}/${pageName}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+  return null;
+}
+
+/**
+ * Poll a single repository's wiki for content updates.
+ *
+ * Strategy: enumerate page slugs, fetch each page's raw content, hash the
+ * body, and only embed pages whose hash differs from the stored value
+ * (or new pages). Deleted pages — present in the store but absent from the
+ * current `_pages` index — are removed from Vectorize, D1 FTS5, and the
+ * structured store, mirroring the doc poller's deletion path.
+ */
+async function pollWiki(
+  repo: string,
+  env: Env,
+  storeStub: DurableObjectStub,
+): Promise<void> {
+  // Cheap existence probe so repos without wiki incur a single HEAD-equivalent
+  // round-trip per cron run instead of three (probe + index + content).
+  const hasWiki = await wikiExists(repo);
+  if (!hasWiki) {
+    console.log(`${repo} wiki: not enabled or not accessible — skip`);
+    return;
+  }
+
+  const pageSlugs = await listWikiPages(repo);
+  if (pageSlugs.length === 0) {
+    console.log(`${repo} wiki: 0 pages discovered`);
+  }
+
+  // Snapshot the existing wiki doc records so we can detect deletes and pick
+  // a per-page preferred extension on subsequent polls.
+  const existingResp = await storeStub.fetch(
+    new Request(`http://store/wiki-docs?repo=${encodeURIComponent(repo)}`),
+  );
+  const existing: WikiDocRecord[] = existingResp.ok
+    ? ((await existingResp.json()) as WikiDocRecord[])
+    : [];
+  const existingMap = new Map(existing.map((w) => [w.pageName, w]));
+  const currentSlugs = new Set(pageSlugs);
+  const deleted = existing.filter((w) => !currentSlugs.has(w.pageName));
+
+  let embedded = 0;
+  let skipped = 0;
+  let failed = 0;
+  let removed = 0;
+
+  for (const pageName of pageSlugs) {
+    if (embedded >= MAX_WIKI_EMBEDDINGS_PER_RUN) {
+      console.warn(
+        `Wiki embedding batch limit reached for ${repo} (${MAX_WIKI_EMBEDDINGS_PER_RUN}). ` +
+          `Remaining wiki pages will be retried next cron run.`,
+      );
+      break;
+    }
+
+    const prior = existingMap.get(pageName);
+    const fetched = await fetchWikiContent(repo, pageName, prior?.extension);
+    if (!fetched) {
+      // The slug was discovered in `_pages` but no extension served. Treat as
+      // a transient miss and skip — the next poll will retry without spending
+      // an embedding budget here.
+      console.warn(`No content fetched for ${repo}/wiki/${pageName} (all extensions 404)`);
+      failed++;
+      continue;
+    }
+
+    const contentHash = await sha256Hex(fetched.content);
+    if (prior && prior.contentHash === contentHash && prior.extension === fetched.extension) {
+      skipped++;
+      continue;
+    }
+
+    const result = await processAndUpsertWikiDoc(
+      env,
+      storeStub,
+      repo,
+      pageName,
+      fetched.extension,
+      fetched.content,
+    );
+
+    if (result.embedded) {
+      embedded++;
+    } else if (result.failed) {
+      failed++;
+    }
+  }
+
+  // Handle deleted pages: remove from Vectorize, FTS5, and the store.
+  for (const wikiDoc of deleted) {
+    try {
+      const wvid = await wikiDocVectorId(repo, wikiDoc.pageName);
+      await env.VECTORIZE.deleteByIds([wvid]);
+      try {
+        await deleteFtsRow(env.DB_FTS, wvid);
+      } catch (ftsErr) {
+        console.error(
+          `Failed to delete FTS5 row for wiki ${repo}/${wikiDoc.pageName}:`,
+          ftsErr instanceof Error ? ftsErr.message : String(ftsErr),
+        );
+      }
+      await storeStub.fetch(
+        new Request(
+          `http://store/wiki-doc?repo=${encodeURIComponent(repo)}&page=${encodeURIComponent(wikiDoc.pageName)}`,
+          { method: "DELETE" },
+        ),
+      );
+      removed++;
+    } catch (err) {
+      console.error(
+        `Failed to delete wiki vector ${repo}/${wikiDoc.pageName}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  console.log(
+    `${repo} wiki: ${pageSlugs.length} pages, ${embedded} embedded, ${skipped} unchanged, ${failed} failed, ${removed} deleted`,
+  );
+}
+
 // ── Comment / review backfill ────────────────────────────────
 
 /** Identify whether an issue record represents a pull request (has the PR surface) */
@@ -1196,6 +1467,8 @@ const LIGHT_CRON = "0 * * * *";
 const COMMENTS_CRON = "15 * * * *";
 /** Cron expression that triggers the diffs-only dispatch. */
 const DIFFS_CRON = "30 * * * *";
+/** Cron expression that triggers the wiki-only dispatch. */
+const WIKI_CRON = "45 * * * *";
 
 /**
  * Run the lightweight surfaces (issues, releases, docs) for one repo.
@@ -1276,6 +1549,27 @@ async function runDiffsSurface(
 }
 
 /**
+ * Run the wiki-content surface for one repo.
+ * Lives in its own cron invocation because each wiki page upsert fans out to
+ * Workers AI embed + Vectorize + D1 FTS + Store DO, and wiki page enumeration
+ * additionally requires an HTML scrape that can be heavy on busy wikis.
+ */
+async function runWikiSurface(
+  repo: string,
+  env: Env,
+  storeStub: DurableObjectStub,
+): Promise<void> {
+  try {
+    await pollWiki(repo, env, storeStub);
+  } catch (err) {
+    console.error(
+      `Failed to poll wiki for ${repo}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/**
  * Main scheduled handler — dispatched by cron expression so each invocation
  * gets its own Cloudflare Workers subrequest budget.
  *
@@ -1343,6 +1637,13 @@ export async function handleScheduled(
   if (controller.cron === DIFFS_CRON) {
     for (const repo of repos) {
       await runDiffsSurface(repo, env, storeStub);
+    }
+    return;
+  }
+
+  if (controller.cron === WIKI_CRON) {
+    for (const repo of repos) {
+      await runWikiSurface(repo, env, storeStub);
     }
     return;
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,6 +10,7 @@ import type {
   IssueRecord,
   ReleaseRecord,
   DocRecord,
+  WikiDocRecord,
   DiffRecord,
   DiffFileStatus,
   IssueCommentRecord,
@@ -53,6 +54,16 @@ type DocRow = {
   repo: string;
   path: string;
   blob_sha: string;
+  updated_at: string;
+};
+
+/** Row shape returned by SQLite for the wiki_docs table */
+type WikiDocRow = {
+  [key: string]: SqlStorageValue;
+  repo: string;
+  page_name: string;
+  extension: string;
+  content_hash: string;
   updated_at: string;
 };
 
@@ -196,6 +207,16 @@ function rowToDocRecord(row: DocRow): DocRecord {
   };
 }
 
+function rowToWikiDocRecord(row: WikiDocRow): WikiDocRecord {
+  return {
+    repo: row.repo,
+    pageName: row.page_name,
+    extension: row.extension,
+    contentHash: row.content_hash,
+    updatedAt: row.updated_at,
+  };
+}
+
 function rowToDiffRecord(row: DiffRow): DiffRecord {
   return {
     repo: row.repo,
@@ -286,6 +307,26 @@ export class IssueStore implements DurableObject {
     this.sql.exec(`
       CREATE INDEX IF NOT EXISTS idx_docs_repo
         ON docs (repo, updated_at DESC);
+    `);
+
+    // Wiki page records — content hash drives change detection (no git blob SHA
+    // available without invoking git smart HTTP). `extension` records which
+    // markup file extension actually serves the page so subsequent polls can
+    // hit the right raw URL directly.
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS wiki_docs (
+        repo         TEXT NOT NULL,
+        page_name    TEXT NOT NULL,
+        extension    TEXT NOT NULL DEFAULT 'md',
+        content_hash TEXT NOT NULL DEFAULT '',
+        updated_at   TEXT NOT NULL,
+        PRIMARY KEY (repo, page_name)
+      );
+    `);
+
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS idx_wiki_docs_repo
+        ON wiki_docs (repo, updated_at DESC);
     `);
 
     this.sql.exec(`
@@ -628,6 +669,72 @@ export class IssueStore implements DurableObject {
 
     const cursor = this.sql.exec<DocRow>(query, ...params);
     return [...cursor].map(rowToDocRecord);
+  }
+
+  // ---- Wiki doc CRUD ----
+
+  upsertWikiDoc(record: WikiDocRecord): void {
+    this.sql.exec(
+      `INSERT INTO wiki_docs (repo, page_name, extension, content_hash, updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT (repo, page_name) DO UPDATE SET
+         extension    = excluded.extension,
+         content_hash = excluded.content_hash,
+         updated_at   = excluded.updated_at`,
+      record.repo,
+      record.pageName,
+      record.extension,
+      record.contentHash,
+      record.updatedAt,
+    );
+  }
+
+  getWikiDoc(repo: string, pageName: string): WikiDocRecord | null {
+    const cursor = this.sql.exec<WikiDocRow>(
+      `SELECT * FROM wiki_docs WHERE repo = ? AND page_name = ?`,
+      repo,
+      pageName,
+    );
+    const rows = [...cursor];
+    if (rows.length === 0) return null;
+    return rowToWikiDocRecord(rows[0]);
+  }
+
+  listWikiDocsByRepo(repo: string): WikiDocRecord[] {
+    const cursor = this.sql.exec<WikiDocRow>(
+      `SELECT * FROM wiki_docs WHERE repo = ? ORDER BY page_name ASC`,
+      repo,
+    );
+    return [...cursor].map(rowToWikiDocRecord);
+  }
+
+  getRecentWikiDocs(
+    opts?: { since?: string; limit?: number; repo?: string },
+  ): WikiDocRecord[] {
+    const limit = opts?.limit ?? 20;
+    const since = opts?.since ?? new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+    let query: string;
+    let params: (string | number)[];
+
+    if (opts?.repo) {
+      query = `SELECT * FROM wiki_docs WHERE repo = ? AND updated_at >= ? ORDER BY updated_at DESC LIMIT ?`;
+      params = [opts.repo, since, limit];
+    } else {
+      query = `SELECT * FROM wiki_docs WHERE updated_at >= ? ORDER BY updated_at DESC LIMIT ?`;
+      params = [since, limit];
+    }
+
+    const cursor = this.sql.exec<WikiDocRow>(query, ...params);
+    return [...cursor].map(rowToWikiDocRecord);
+  }
+
+  deleteWikiDoc(repo: string, pageName: string): void {
+    this.sql.exec(
+      `DELETE FROM wiki_docs WHERE repo = ? AND page_name = ?`,
+      repo,
+      pageName,
+    );
   }
 
   /**
@@ -1191,6 +1298,57 @@ export class IssueStore implements DurableObject {
           repo,
         });
         return Response.json(items);
+      }
+
+      // POST /upsert-wiki-doc — upsert a single wiki doc record
+      if (request.method === "POST" && path === "/upsert-wiki-doc") {
+        const record = (await request.json()) as WikiDocRecord;
+        this.upsertWikiDoc(record);
+        return new Response("ok", { status: 200 });
+      }
+
+      // GET /wiki-doc?repo=...&page=... — get a single wiki doc record
+      if (request.method === "GET" && path === "/wiki-doc") {
+        const repo = url.searchParams.get("repo");
+        const pageName = url.searchParams.get("page");
+        if (!repo || !pageName) {
+          return new Response("missing repo or page", { status: 400 });
+        }
+        const wikiDoc = this.getWikiDoc(repo, pageName);
+        if (!wikiDoc) return new Response("not found", { status: 404 });
+        return Response.json(wikiDoc);
+      }
+
+      // GET /wiki-docs?repo=... — list wiki docs by repo
+      if (request.method === "GET" && path === "/wiki-docs") {
+        const repo = url.searchParams.get("repo");
+        if (!repo) return new Response("missing repo", { status: 400 });
+        const wikiDocs = this.listWikiDocsByRepo(repo);
+        return Response.json(wikiDocs);
+      }
+
+      // GET /recent-wiki-docs?since=...&limit=...&repo=... — recent wiki doc activity
+      if (request.method === "GET" && path === "/recent-wiki-docs") {
+        const since = url.searchParams.get("since") ?? undefined;
+        const limit = url.searchParams.get("limit");
+        const repo = url.searchParams.get("repo") ?? undefined;
+        const items = this.getRecentWikiDocs({
+          since,
+          limit: limit ? parseInt(limit, 10) : undefined,
+          repo,
+        });
+        return Response.json(items);
+      }
+
+      // DELETE /wiki-doc?repo=...&page=... — delete a wiki doc record
+      if (request.method === "DELETE" && path === "/wiki-doc") {
+        const repo = url.searchParams.get("repo");
+        const pageName = url.searchParams.get("page");
+        if (!repo || !pageName) {
+          return new Response("missing repo or page", { status: 400 });
+        }
+        this.deleteWikiDoc(repo, pageName);
+        return new Response("ok", { status: 200 });
       }
 
       // DELETE /doc?repo=...&path=... — delete a doc record

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,29 @@ export interface DocRecord {
 }
 
 /**
+ * Stored wiki page record in Durable Object SQLite.
+ *
+ * GitHub Wiki content lives in a separate git repo (`{repo}.wiki.git`) and is
+ * not exposed through the GitHub REST API. We enumerate pages by scraping the
+ * `/{repo}/wiki/_pages` HTML index and fetch raw content via
+ * `https://raw.githubusercontent.com/wiki/{repo}/master/{page}.{ext}`.
+ *
+ * `pageName` matches the GitHub Wiki page identifier (URL slug, dash-separated
+ * for spaces). `extension` records which markup file extension actually serves
+ * the page so subsequent polls can hit the right raw URL directly without
+ * trying every supported extension. `contentHash` is a SHA-256 over the raw
+ * content body and drives change detection (no git blob SHA is available
+ * without invoking the git smart-HTTP protocol).
+ */
+export interface WikiDocRecord {
+  repo: string;
+  pageName: string;
+  extension: string;
+  contentHash: string;
+  updatedAt: string;
+}
+
+/**
  * Stored top-level comment record (issues + PRs) in Durable Object SQLite.
  * `number` is the parent issue or PR number (issues and PRs share the same number space).
  */
@@ -125,6 +148,7 @@ export interface VectorMetadata {
     | "pull_request"
     | "release"
     | "doc"
+    | "wiki_doc"
     | "diff"
     | "issue_comment"
     | "pr_review"
@@ -138,6 +162,10 @@ export interface VectorMetadata {
   tag_name?: string;
   /** Document file path (docs only) */
   doc_path?: string;
+  /** Wiki page name / slug (wiki_doc only) */
+  wiki_path?: string;
+  /** Wiki page file extension (wiki_doc only, e.g., "md", "markdown", "org", "rst") */
+  wiki_extension?: string;
   /** Commit SHA (diffs only) */
   commit_sha?: string;
   /** File path inside the commit (diffs only) */

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -57,8 +57,9 @@ binding = "AI"
 #   :00 — light surfaces  (issues, releases, docs)
 #   :15 — comments surface (pollComments)
 #   :30 — diffs surface    (pollDiffs)
+#   :45 — wiki surface     (pollWiki — issue #128)
 [triggers]
-crons = ["0 * * * *", "15 * * * *", "30 * * * *"]
+crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *"]
 
 # Required secrets (set via `wrangler secret put <NAME>`):
 # GITHUB_CLIENT_ID      — GitHub App OAuth client ID


### PR DESCRIPTION
## 概要

GitHub Wiki コンテンツを github-rag-mcp の RAG index に取り込む新規 ingestion 経路を追加。\`mcp__github-rag-mcp__search\` で wiki ページが他 surface と同列に検索結果に出る。Liplus-Project/liplus-language で進行中の判断記録 wiki 寄せ運用の前提条件。

## 設計判断（事前 lock 済み）

| # | 軸 | 採用 |
|---|---|---|
| 1 | 取り込み範囲 | wiki がサポートする text-based 全種 (md / markdown / mediawiki / org / rst / rest / textile / pod / asciidoc / creole) |
| 2 | type 表現 | 新 type \`wiki_doc\`（既存 \`doc\` と並列、同名でも別ヒット）|
| 3 | 対象 repo | 既存 \`POLL_REPOS\` 自動。wiki 存在は \`{repo}.wiki.git/info/refs?service=git-upload-pack\` で 200 検出、404 = skip |
| 4 | poll 頻度 | 独立 cron \`45 * * * *\` (light :00 / comments :15 / diffs :30 と staggered) |
| 5 | conflict | docs/ と wiki 両方 index、type で区別 |
| 6 | include_content | wiki page から raw URL fetch (\`raw.githubusercontent.com/wiki/{repo}/master/{page}.{ext}\`) |
| 7 | result URL | \`https://github.com/{repo}/wiki/{page-name}\` |
| 8 | wiki repo 認識 | smart-HTTP info/refs 200/404 |
| 9 | バージョン | patch (v0.8.4)、v0.x 初期で \`Anything may change\` |
| 10 | 既存 entry 移管 | W4 release 後に liplus-language 側で別 PR |

## 変更内容

Worker side:

- \`src/types.ts\` — \`WikiDocRecord\` interface + \`VectorMetadata.type\` 拡張 + \`wiki_path\` / \`wiki_extension\` 追加
- \`src/store.ts\` — DO SQLite \`wiki_docs\` table + idempotent CREATE + CRUD アクセサ + HTTP handler 4 種 (\`/upsert-wiki-doc\` / \`/wiki-doc\` GET/DELETE / \`/wiki-docs\` / \`/recent-wiki-docs\`)
- \`src/pipeline.ts\` — \`wikiDocVectorId\` (prefix \`w\`) + \`processAndUpsertWikiDoc\` + \`sha256Hex\` helper export
- \`src/poller.ts\` — \`wikiExists\` (smart-HTTP probe) / \`listWikiPages\` (\`_pages\` HTML scrape) / \`fetchWikiContent\` (拡張子 probe + 前回ヒット拡張子 cache) / \`pollWiki\` + \`WIKI_CRON\` dispatch
- \`src/mcp.ts\` — type filter enum 拡張 / scan mode wiki block / search mode metadata mapping / URL builder / title 補完 / \`inlineDocContent\` を doc + wiki 並列 fetch に拡張
- \`wrangler.toml\` — crons に \`45 * * * *\` 追加

Schema impact:

- D1 \`search_docs\` 既存カラム再利用（migration 不要、\`type='wiki_doc'\` + \`doc_path\` を page slug に流用）
- DO IssueStore \`wiki_docs\` 新規 table、\`CREATE TABLE IF NOT EXISTS\` で既存データ保護
- Vectorize は新 metadata 受け入れ可、schema 変更不要

Docs:

- \`docs/0-requirements{.md,.ja.md}\` — Cron Poller 4 triggers / wiki poller 専用節 / type enum / Structured State Store 棚卸し更新
- \`README{.md,.ja.md}\` / \`mcp-server/README.md\` / \`mcp-server/manifest.json\` — surface coverage / tool description 更新

## テスト

- \`tsc --noEmit -p tsconfig.json\` exit 0
- \`mcp-server/npm test\` (= \`node --check server/index.js\`) pass
- 新規 unit test なし — wiki ingestion は integration-bound（live HTML scrape + raw fetch）、deploy 後の本番 cron で動作観測する設計

## 既存ingestion経路への影響

ゼロ。すべて additive:

- types.ts: union 末尾に追加のみ、既存 type 列挙は変えてない
- store.ts: 既存 doc handler 群は触らず、新 \`/wiki-doc\` 系 endpoint を追加
- pipeline.ts: 既存 \`processAndUpsertDoc\` は触らず、並列の \`processAndUpsertWikiDoc\` 追加
- poller.ts: 既存 light/comments/diffs cron は無修正、\`WIKI_CRON\` のみ新規 dispatch 分岐
- mcp.ts: 既存 result mapping は no-op pass through、wiki_doc rows のみ新 branch
- wrangler.toml: 4th cron 追加のみ

## バージョン

patch (v0.8.4 milestone)。v0.x 初期開発期で additive なので minor bump せず patch 据え置き。

## 関連

- Closes #128
- Liplus-Project/liplus-language#1170 (判断記録 wiki 化、本機能の親動機)
- Liplus-Project/liplus-language#1160 (plugin distribution path)