### PR TITLE
hotfix(poller): cap wiki ingestion subrequest fan-out (#130, patch)

### DIFF
--- a/src/poller.ts
+++ b/src/poller.ts
@@ -788,27 +788,36 @@ async function pollDocs(
 // ── Wiki doc poller ──────────────────────────────────────────
 
 /**
- * Wiki page markup file extensions that GitHub Wiki natively supports
- * (https://github.com/gollum/gollum). Sorted by popularity so the first hit
- * on a fresh page is usually the first probe.
+ * Wiki page markup file extensions probed when no cached extension is available.
+ *
+ * GitHub Wiki natively supports more formats (mediawiki / org / rst / pod /
+ * textile / asciidoc / creole) but the per-page extension probe is a pure
+ * subrequest cost — every miss eats 1 of the Worker's 1000-per-invocation
+ * subrequest budget (issue #130). Markdown is the dominant format in
+ * practice; restricting the probe set to `md` + `markdown` keeps the
+ * worst-case subrequest fan-out predictable while still covering every wiki
+ * we currently care about. Once a page is ingested the actual extension is
+ * cached on its WikiDocRecord and reused on subsequent polls regardless of
+ * this probe-set narrowing.
+ *
+ * Follow-up: re-introduce the rarer extensions behind a per-repo opt-in flag
+ * so the bulk-import worst case stays bounded. Tracked in #130 follow-up.
  */
-const WIKI_EXTENSIONS = [
-  "md",
-  "markdown",
-  "mediawiki",
-  "org",
-  "rst",
-  "rest",
-  "textile",
-  "pod",
-  "asciidoc",
-  "creole",
-] as const;
+const WIKI_EXTENSIONS = ["md", "markdown"] as const;
 
 /** Maximum wiki pages embedded per repo per cron run.
  *  Caps Workers AI embed budget the same way MAX_EMBEDDINGS_PER_RUN does for
  *  repository docs. Remaining changed pages are picked up on the next cron. */
 const MAX_WIKI_EMBEDDINGS_PER_RUN = 30;
+
+/** Maximum wiki pages whose content we *probe* (HTTP fetch) per repo per cron
+ *  run. Distinct from MAX_WIKI_EMBEDDINGS_PER_RUN because probing alone
+ *  consumes Worker subrequests even when the page has not changed (we still
+ *  fetch the raw content to compare hashes). On bulk import this is the
+ *  dominant subrequest cost — cap it so 5+ repos with deep wikis cannot
+ *  exhaust the per-invocation 1000-subrequest ceiling (issue #130). Pages
+ *  beyond the cap are deferred to the next cron run. */
+const MAX_WIKI_PAGES_PROBED_PER_REPO_PER_RUN = 20;
 
 /**
  * Probe whether a repo has a wiki at all.
@@ -971,6 +980,7 @@ async function pollWiki(
   let skipped = 0;
   let failed = 0;
   let removed = 0;
+  let probed = 0;
 
   for (const pageName of pageSlugs) {
     if (embedded >= MAX_WIKI_EMBEDDINGS_PER_RUN) {
@@ -981,7 +991,16 @@ async function pollWiki(
       break;
     }
 
+    if (probed >= MAX_WIKI_PAGES_PROBED_PER_REPO_PER_RUN) {
+      console.warn(
+        `Wiki probe batch limit reached for ${repo} (${MAX_WIKI_PAGES_PROBED_PER_REPO_PER_RUN}). ` +
+          `Each probe consumes a Worker subrequest; bulk imports spread across multiple cron runs.`,
+      );
+      break;
+    }
+
     const prior = existingMap.get(pageName);
+    probed++;
     const fetched = await fetchWikiContent(repo, pageName, prior?.extension);
     if (!fetched) {
       // The slug was discovered in `_pages` but no extension served. Treat as


### PR DESCRIPTION
## 概要

W4 (#128 / PR #129) deploy 後、Cloudflare Worker logs に \`Too many subrequests by single Worker invocation\` が多発。\`pollWiki\` が 1 cron invocation で 5 repos × N pages × 10 extension probe を直列実行して 1000-subrequest/invocation 上限を突破していた。

## 観測した literal

\`\`\`
wikiExists probe failed for Liplus-Project/dipper_ai: Too many subrequests by single Worker invocation
fetchWikiContent probe md/markdown/mediawiki/org/rst/rest/textile/pod/asciidoc/creole failed
  for Liplus-Project/github-rag-mcp/installation.ja: Too many subrequests
\`\`\`

## 修正

| 変更 | 効果 |
|---|---|
| \`WIKI_EXTENSIONS\` = \`["md", "markdown"]\` （8 種削減） | 新規 page の probe 最悪コストが 10 → 2 fetch |
| \`MAX_WIKI_PAGES_PROBED_PER_REPO_PER_RUN = 20\` 新設 | per-repo 1 cron 1 invocation の probe 数を硬く capping |

総 subrequest 見積もり: 5 repos × (20 pages × 1-2 probes + 2 overhead) ≈ 110/invocation。Cloudflare Paid (1000) で安全マージン。

## 挙動の変更

- 大規模 wiki (100+ pages) の初回 import は複数 cron run に分散（20 pages/run × 4 runs/hour = 80 pages/hour/repo）
- mediawiki / org / rst / pod / textile / asciidoc / creole 形式の wiki page は本 hotfix では未 index（該当 wiki がプロジェクト内に現状存在しない）。follow-up で per-repo opt-in flag 経由の再導入候補

## バージョン

patch (v0.8.5)。hotfix、production 障害解消が目的。

## テスト

- \`tsc --noEmit\` exit 0
- 既存 mcp-server test pass (\`node --check\` のみ)

## 関連

- 元実装: #128 / PR #129
- Closes #130