### PR TITLE
hotfix(poller, mcp): drop spurious /master/ branch segment from wiki raw URL (#132, patch)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1283,7 +1283,7 @@ export class RagMcpAgentV2 extends McpAgent<Env, unknown, McpProps> {
         const itemRepo = row.repo ?? fallbackRepo ?? "";
         const ext = row.wiki_extension || "md";
         if (!pageName || !itemRepo) return;
-        const url = `https://raw.githubusercontent.com/wiki/${itemRepo}/master/${encodeURIComponent(pageName)}.${ext}`;
+        const url = `https://raw.githubusercontent.com/wiki/${itemRepo}/${encodeURIComponent(pageName)}.${ext}`;
         try {
           const res = await fetch(url, {
             headers: { "User-Agent": "github-rag-mcp/0.1.0" },

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -901,7 +901,8 @@ async function listWikiPages(repo: string): Promise<string[]> {
 /**
  * Fetch a wiki page's raw markup content.
  *
- * GitHub serves wiki content from `raw.githubusercontent.com/wiki/{repo}/master/{page}.{ext}`.
+ * GitHub serves wiki content from `raw.githubusercontent.com/wiki/{repo}/{page}.{ext}`
+ * (no branch segment — wiki raw URLs route directly without referencing master/main).
  * If `preferredExtension` is provided (i.e. the page is already known from a
  * previous poll), try it first to skip the multi-extension probe. Otherwise
  * iterate through every supported extension until one returns 200.
@@ -919,7 +920,7 @@ async function fetchWikiContent(
     : Array.from(WIKI_EXTENSIONS);
 
   for (const ext of probes) {
-    const url = `https://raw.githubusercontent.com/wiki/${repo}/master/${encodeURIComponent(pageName)}.${ext}`;
+    const url = `https://raw.githubusercontent.com/wiki/${repo}/${encodeURIComponent(pageName)}.${ext}`;
     try {
       const resp = await fetch(url, {
         headers: { "User-Agent": "github-rag-mcp/0.1.0" },


### PR DESCRIPTION
## 概要

#131 deploy 後の :45 cron 実機観測で wiki ingestion の全 page が 404 で失敗していることが判明。GitHub Wiki raw URL pattern に \`/master/\` を含めたのが原因。

## 観測 (literal)

\`\`\`
Liplus-Project/github-rag-mcp wiki: 6 pages, 0 embedded, 0 unchanged, 6 failed, 0 deleted
No content fetched for Liplus-Project/github-rag-mcp/wiki/installation.ja (all extensions 404)
fetchWikiContent probe md failed for Liplus-Project/liplus-language/e.-...
fetchWikiContent probe markdown failed for Liplus-Project/liplus-language/e.-...
\`\`\`

\`Too many subrequests\` は #131 で解消、新たな 404 layer のみ残存。

## 根本原因

\`\`\`
raw.githubusercontent.com/wiki/{repo}/master/{page}.md  → 404
raw.githubusercontent.com/wiki/{repo}/main/{page}.md    → 404
raw.githubusercontent.com/wiki/{repo}/{page}.md         → 200
\`\`\`

GitHub Wiki raw URL は branch segment を取らない仕様。W4 (#129) 実装で \`git ls-remote\` の \`master\` ref から類推して \`/master/\` を URL に入れたのが間違い。git protocol 内部の話で raw routing は branch を含まない。

## 修正

URL string 1 行を 2 ファイル:
- \`src/poller.ts\` \`fetchWikiContent\` (cron-side ingestion)
- \`src/mcp.ts\` \`inlineDocContent\` (search-time include_content for wiki rows)

加えてコメント 1 箇所を branch-less pattern に更新。

## バージョン

patch (v0.8.5 milestone) — #131 と同 hotfix milestone。

## 関連

- Closes #132
- 元実装: #128 / PR #129 (W4)
- 関連 hotfix: #130 / PR #131 (subrequest cap、本 bug を unmask)