### PR TITLE
fix(poller): cap pollComments fetches per repo per invocation

### DIFF
--- a/src/poller.ts
+++ b/src/poller.ts
@@ -59,6 +59,18 @@ const MAX_COMMENT_BACKFILL_PARENTS = 20;
  *  Workers AI embed calls are the dominant cost for the comment surface. */
 const MAX_COMMENTS_EMBEDDED_PER_REPO = 30;
 
+/** Maximum number of GitHub API *fetches* the comment poller issues per repo
+ *  per cron run. Distinct from MAX_COMMENTS_EMBEDDED_PER_REPO because each
+ *  parent fans out to up to 3 endpoints (issue comments + PR reviews + PR
+ *  review comments) and every fetch consumes 1 of the Worker's
+ *  1000-subrequest-per-invocation budget — even on parents whose comments are
+ *  unchanged and embed-skipped. With MAX_COMMENT_BACKFILL_PARENTS = 20 the
+ *  worst-case fan-out is 60 fetches per repo, which combined with diff / wiki
+ *  / issue pollers exhausts the budget on busy repos (issue #134, observed on
+ *  Liplus-Project/dipper_ai). Capping fetches keeps the comment surface's
+ *  worst-case bounded; remaining parents are picked up on the next cron. */
+const MAX_COMMENT_FETCHES_PER_REPO_PER_RUN = 30;
+
 /** Maximum number of commits fetched in the forward (webhook-redundancy) phase
  *  of the diff poller per repo per run.
  *  Forward is normally a no-op because the webhook path already indexes new
@@ -1190,15 +1202,24 @@ async function pollComments(
   let reviewCommentsSkipped = 0;
   let reviewCommentsFiltered = 0;
   let fetchFailures = 0;
+  let fetchesIssued = 0;
+  let fetchBudgetExhausted = false;
 
   const embedBudget = (): boolean =>
     commentsEmbedded + reviewsEmbedded + reviewCommentsEmbedded < MAX_COMMENTS_EMBEDDED_PER_REPO;
 
+  const fetchBudget = (): boolean => fetchesIssued < MAX_COMMENT_FETCHES_PER_REPO_PER_RUN;
+
   for (const parent of parents) {
     if (!embedBudget()) break;
+    if (!fetchBudget()) {
+      fetchBudgetExhausted = true;
+      break;
+    }
 
     // Top-level comments (issues and PRs both route through /issues/{N}/comments)
     try {
+      fetchesIssued++;
       const comments = await fetchIssueComments(repo, parent.number, env.GITHUB_TOKEN);
       for (const c of comments) {
         if (!embedBudget()) break;
@@ -1219,8 +1240,13 @@ async function pollComments(
     if (!isPullRequestRecord(parent)) continue;
 
     if (!embedBudget()) break;
+    if (!fetchBudget()) {
+      fetchBudgetExhausted = true;
+      break;
+    }
 
     try {
+      fetchesIssued++;
       const reviews = await fetchPRReviews(repo, parent.number, env.GITHUB_TOKEN);
       for (const r of reviews) {
         if (!embedBudget()) break;
@@ -1238,8 +1264,13 @@ async function pollComments(
     }
 
     if (!embedBudget()) break;
+    if (!fetchBudget()) {
+      fetchBudgetExhausted = true;
+      break;
+    }
 
     try {
+      fetchesIssued++;
       const inline = await fetchPRReviewComments(repo, parent.number, env.GITHUB_TOKEN);
       for (const rc of inline) {
         if (!embedBudget()) break;
@@ -1257,8 +1288,17 @@ async function pollComments(
     }
   }
 
+  if (fetchBudgetExhausted) {
+    console.warn(
+      `pollComments: fetch budget reached for ${repo} ` +
+        `(${MAX_COMMENT_FETCHES_PER_REPO_PER_RUN} fetches). Each parent fans out to up ` +
+        `to 3 endpoints; remaining parents are deferred to the next cron run.`,
+    );
+  }
+
   console.log(
     `${repo} comments: scanned ${parents.length} parents, ` +
+      `fetches_issued=${fetchesIssued}/${MAX_COMMENT_FETCHES_PER_REPO_PER_RUN}, ` +
       `top-level [embedded=${commentsEmbedded}, skipped=${commentsSkipped}, filtered=${commentsFiltered}], ` +
       `reviews [embedded=${reviewsEmbedded}, skipped=${reviewsSkipped}, filtered=${reviewsFiltered}], ` +
       `inline [embedded=${reviewCommentsEmbedded}, skipped=${reviewCommentsSkipped}, filtered=${reviewCommentsFiltered}], ` +


### PR DESCRIPTION
## 概要

`pollComments` の per-repo fetch 数に上限を追加し、Cloudflare Worker の 1 起動あたり 1000 subrequest 上限を超過する問題を修正する。

## 背景

2026-04-26 の cron 実行で、`Liplus-Project/dipper_ai` の `pollComments` が `Too many subrequests by single Worker invocation` で落ちている事象が観測された (issue #134)。他の 4 repo (`github-rag-mcp` / `github-webhook-mcp` / `liplus-language` / `liplus-desktop`) では同事象は出ていない。

既存の cap は 2 段:
- `MAX_COMMENT_BACKFILL_PARENTS = 20` (per-repo の parent 数上限)
- `MAX_COMMENTS_EMBEDDED_PER_REPO = 30` (per-repo の embedding 数上限)

ただし各 parent は 3 endpoint (issue comments / PR reviews / PR review comments) に fan-out するため、最悪ケースで 1 repo あたり 60 fetch を発行する。dipper_ai のように comment 量の多い repo では、他の poller (diff / wiki / issue) と合算して subrequest budget を使い切る。

## 修正方針

#130 / PR #131 (wiki 側) と同じパターンを採用する。embed cap とは独立した「fetch (probe) cap」を導入する。

- 新定数 `MAX_COMMENT_FETCHES_PER_REPO_PER_RUN = 30` を追加
- per-parent loop 内で fetch 発行のたびに counter を increment
- 上限到達で loop を打ち切り、warn log を出力
- summary log に `fetches_issued=N/MAX` を追加して観測しやすくする

cap 値 30 は wiki 側の `MAX_WIKI_PAGES_PROBED_PER_REPO_PER_RUN = 20` と整合的なオーダで、`MAX_COMMENTS_EMBEDDED_PER_REPO` と同じ値に揃えた。最大 30 fetch なら 5 repo 並走でも 150 subrequest で、他 poller と合算しても 1000 budget に収まる。

## 既存挙動への影響

- 4 つの稼働中 repo は parent 数 × 3 endpoint が常時 30 fetch 未満で動いているため、挙動退行はない。
- dipper_ai のように cap に到達する repo では、未処理 parent は次の cron で自然に拾われる (cron は hourly)。

## ファイル

- `src/poller.ts` (+40, -0)

## テスト

- `npx tsc --noEmit` pass

## 補足

execution mode = `auto` のため、本 PR は AI 自律 self-review を経て merge する。

Closes #134