### PR TITLE
chore(fts): enrich D1 upsert failure logs to surface root cause (#135)

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1183,9 +1183,25 @@ export async function processAndUpsertCommitDiff(
           content: inputs[i],
         });
       } catch (ftsErr) {
+        // Keep the high-level line for log searchability, then surface the underlying
+        // D1 error shape on a second line so the next cron run produces actionable
+        // context (error name, vector_id, content/path sizes). See #135.
         console.error(
           `Failed to upsert FTS5 row for diff ${repo}@${commitSha}/${f.filename}:`,
           ftsErr instanceof Error ? ftsErr.message : String(ftsErr),
+        );
+        console.error(
+          `FTS5 diff upsert detail (#135):`,
+          JSON.stringify({
+            errorName: ftsErr instanceof Error ? ftsErr.name : typeof ftsErr,
+            vectorId: v.id,
+            tokenizerKind: "code",
+            contentChars: inputs[i].length,
+            filePathChars: f.filename.length,
+            fileStatus: normaliseFileStatus(f.status),
+            commitSha,
+            repo,
+          }),
         );
       }
     }


### PR DESCRIPTION
## 概要

`processAndUpsertCommitDiff` の FTS5 upsert 失敗時に出ているログ (`Failed to upsert FTS5 row for diff ...`) が `ftsErr.message` のみで根本原因が特定できないため、構造化詳細行を追加する観測強化 PR。

## 選択肢

#135 が提示している 2 候補のうち **Option B (log enrichment)** を選択。

理由:
- 現状ログから D1 側の具体エラー型 (D1_ERROR / SQLITE_CORRUPT_VTAB / その他) が判別できない
- cross-repo かつ diff のみという発生パターンは強い signal だが、コードリーディングだけでは根本原因 (trigram tokenizer 限界 / content size / 特殊バイト / 過去の VTAB corruption 再発 など仮説複数) を一意に決められない
- Option A (ノーエビデンスでの推測修正) はリスクが高く最小修正の原則から外れる
- #135 自体「first step として log enrichment」と明示

## 変更内容

`src/pipeline.ts` の diff 用 FTS5 upsert catch ブロック 1 箇所のみ:
- 既存の "Failed to upsert FTS5 row for diff ..." 行は検索性のため温存
- 新規 `FTS5 diff upsert detail (#135):` 行を追加し、JSON で以下を出力:
  - `errorName` (Error.name / typeof — D1_ERROR か他か判別)
  - `vectorId` (該当 SHA-256 base64url ID)
  - `tokenizerKind: "code"` (trigram 仮説の確認用)
  - `contentChars` (8000 上限近接かどうか)
  - `filePathChars` (path 長さ仮説)
  - `fileStatus` (added/modified 等 status との相関)
  - `commitSha`, `repo`

diff stat: `src/pipeline.ts | 16 ++++++++++++++++` 1 file, +16/-0.

## 検証

- `npx tsc --noEmit` exit 0 (型エラーなし)
- 他のサーフェス (issue / release / doc / wiki / comment / review) の FTS5 catch は手付かず — diff 経路のみ失敗が観測されているため scope 最小化

## 後続

このログが次回以降の cron 実行で蓄積されたあと、別 issue/PR で root-cause fix を行う。issue #135 はそれまで open のまま (`Refs #135`、`Closes` ではない)。

## 実行モード

`auto` mode、AI 自律 self-review 経由で merge。`--auto` flag は付けない (operations.md auto mode rule に準拠)。