### PR TITLE
fix(fts): drop and recreate code_fts to clear recurring SQLITE_CORRUPT_VTAB

### DIFF
--- a/migrations/0003_fts5_code_recreate.sql
+++ b/migrations/0003_fts5_code_recreate.sql
@@ -1,0 +1,37 @@
+-- D1 FTS5 code_fts virtual table fresh recreate — recurring SQLITE_CORRUPT_VTAB
+--
+-- Layer = L4 Operations (sparse retrieval surface recovery)
+--
+-- Context:
+--   2026-04-24: migration 0002 applied FTS5 'rebuild' to both nat_fts and code_fts
+--   to recover from SQLITE_CORRUPT_VTAB.
+--   2026-04-28: corruption recurred on code_fts only (trigram tokenizer side).
+--   Enriched logs from PR #137 confirmed errorName=Error /
+--   D1_ERROR: database disk image is malformed: SQLITE_CORRUPT_VTAB on every diff
+--   upsert across all 5 polled repos.
+--
+-- Recovery (more aggressive than 0002):
+--   DROP the corrupted virtual table and recreate it from scratch with the
+--   same definition as 0001, then repopulate via FTS5 'rebuild' which reads
+--   from the content-owner table (search_docs).
+--
+--   Triggers from 0001 (trg_search_docs_ai/ad/au) reference search_docs_code_fts
+--   by name; they resume working as soon as the new table exists, so they do
+--   not need to be redefined.
+--
+-- Scope:
+--   Affects code_fts only. nat_fts is untouched (no recurring corruption observed there).
+--
+-- Idempotency:
+--   IF EXISTS / IF NOT EXISTS clauses keep the migration safe to re-run.
+
+DROP TABLE IF EXISTS search_docs_code_fts;
+
+CREATE VIRTUAL TABLE IF NOT EXISTS search_docs_code_fts USING fts5 (
+  content,
+  tokenize = 'trigram case_sensitive 0',
+  content = 'search_docs',
+  content_rowid = 'rowid'
+);
+
+INSERT INTO search_docs_code_fts(search_docs_code_fts) VALUES('rebuild');


### PR DESCRIPTION
## 概要

D1 FTS5 仮想テーブル `search_docs_code_fts` (trigram tokenizer) で `SQLITE_CORRUPT_VTAB` が再発し続けている件 (#135) の根本対処。`DROP TABLE` + `CREATE VIRTUAL TABLE` + FTS5 `'rebuild'` でテーブル本体を作り直す migration 0003 を追加する。

`Closes #135`

## 経緯 (なぜ 0002 から 0003 へ)

- 2026-04-24: migration 0002 で `nat_fts` / `code_fts` 両方に FTS5 `'rebuild'` を適用して SQLITE_CORRUPT_VTAB を一旦解消。
- 2026-04-28: PR #137 のログ強化で `errorName=Error` / `D1_ERROR: database disk image is malformed: SQLITE_CORRUPT_VTAB` が **`code_fts` 側のみ** 全 5 リポジトリの diff upsert で再発していることを確認 (`tokenizerKind=code, contentChars=965-1164`)。
- `'rebuild'` は内部インデックスの再構築だが、仮想テーブル本体のメタ構造そのものが malformed の場合は不十分。テーブルを DROP して作り直すのがより徹底した対処。

## 変更内容

- 追加: `migrations/0003_fts5_code_recreate.sql`
  - `DROP TABLE IF EXISTS search_docs_code_fts;`
  - `CREATE VIRTUAL TABLE IF NOT EXISTS search_docs_code_fts USING fts5 (...)` — 0001 の定義と完全一致 (trigram, case_sensitive=0, content=search_docs, content_rowid=rowid)
  - `INSERT INTO search_docs_code_fts(search_docs_code_fts) VALUES('rebuild');` — `search_docs` から再投入
- ソースコード変更なし (`src/pipeline.ts` / `src/fts.ts` は正しい。corruption は D1 schema 状態のみの問題)。

## 影響範囲

- `search_docs_code_fts` のみ。`search_docs_nat_fts` は再発が観測されていないため触らない。
- 0001 のトリガ (`trg_search_docs_ai`/`ad`/`au`) はテーブル名参照のため、新テーブル作成後にそのまま機能する。
- migration 適用中に `search_docs` と `search_docs_code_fts` が一時的に乖離するが、`pollDiffs` 側に try/catch があるため許容範囲。

## 適用手順 (merge 後 Master が実行)

```
npx wrangler d1 migrations apply github-rag-fts --remote
```

(`package.json` に専用スクリプトはないため raw コマンド。D1 binding 名 = `DB_FTS`、database_name = `github-rag-fts`。)

## 実行モード

auto mode。CI pass 後に AI が self-review し、parent agent が squash merge する。