### PR TITLE
feat(mcp): add alwaysLoad: true to plugin .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "github-rag-mcp": {
+      "type": "http",
+      "url": "https://github-rag.smgjp.com/mcp",
+      "alwaysLoad": true,
+      "note": "GitHub RAG MCP. OAuth is required on first use."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- plugin root に `.mcp.json` を新規追加し、`github-rag-mcp` server config に `alwaysLoad: true` を指定する。
- Claude Code v2.1.121 (release: 2026-04-28) で追加された `alwaysLoad` オプションにより、当該 server の全 tool が tool-search deferral を skip し常時 prompt に常駐する。
- research 経路で常用する RAG tool を deferred 状態から `ToolSearch` 経由でロードする 1 往復を毎ターン削減する。
- 旧 Claude Code は未知 field として無視するため後方互換。

## Test plan

- [x] `.mcp.json` が plugin root に存在し JSON として valid であること
- [x] field 順序 (`type` -> `url` -> `alwaysLoad` -> `note`) が issue 提案どおりであること
- [ ] CI green
- [ ] Claude Code v2.1.121+ 環境で plugin 再読込時に `github-rag-mcp` server の tool が deferred 表示されないこと (post-merge 動作確認)

Closes #139