### PR TITLE
fix(poller): lower pollComments cap from 30 to 10 to fit Worker subrequest budget

### DIFF
--- a/src/poller.ts
+++ b/src/poller.ts
@@ -68,8 +68,21 @@ const MAX_COMMENTS_EMBEDDED_PER_REPO = 30;
  *  worst-case fan-out is 60 fetches per repo, which combined with diff / wiki
  *  / issue pollers exhausts the budget on busy repos (issue #134, observed on
  *  Liplus-Project/dipper_ai). Capping fetches keeps the comment surface's
- *  worst-case bounded; remaining parents are picked up on the next cron. */
-const MAX_COMMENT_FETCHES_PER_REPO_PER_RUN = 30;
+ *  worst-case bounded; remaining parents are picked up on the next cron.
+ *
+ *  Numeric history (issue #134):
+ *    - PR #136 (merged 2026-04-27) introduced this cap at 30 as the initial
+ *      defense.
+ *    - 2026-04-28T15:15 UTC :15 cron observation (post-redeploy +33min): all
+ *      5 polled repos still hit `fetches_issued=30/30, fetch_failures=30,
+ *      Too many subrequests`. The cap fires (warn `pollComments: fetch budget
+ *      reached`), but the 1000-subrequest-per-invocation budget is exhausted
+ *      before fetches reach 30. Each fetch carries multi-subrequest overhead
+ *      (Vectorize embed + D1 FTS upsert + Workers AI + Store DO calls), so
+ *      5 repos × 30 fetches × ~3-5 subrequests easily blows past 1000.
+ *    - Lowered to 10: worst-case 5 × 10 = 50 fetches × ~5 subrequests ≈ 250,
+ *      leaving headroom for per-parent overhead and other pollers. */
+const MAX_COMMENT_FETCHES_PER_REPO_PER_RUN = 10;
 
 /** Maximum number of commits fetched in the forward (webhook-redundancy) phase
  *  of the diff poller per repo per run.


### PR DESCRIPTION
## 概要

`src/poller.ts` の `MAX_COMMENT_FETCHES_PER_REPO_PER_RUN` を 30 から 10 に引き下げる。PR #136 で 30 を導入した直後の本番観測で、cap=30 でも `Too many subrequests` が解消していないことを確認したため。

## 観測根拠

2026-04-28T15:15 UTC の `:15` pollComments cron (再デプロイから約 33 分後):

- 5 repos すべてで `fetches_issued=30/30, fetch_failures=30, Too many subrequests`
- 警告 `pollComments: fetch budget reached` は発火しているが、cap=30 に到達する前に Worker の 1000-subrequest-per-invocation budget を使い切っている
- 1 fetch あたりに Vectorize embed + D1 FTS upsert + Workers AI + Store DO 呼び出しなどの overhead が乗るため、5 repos × 30 fetches × ~3-5 subrequests で 1000 を超過

## 数値根拠

- cap=10: worst-case 5 × 10 = 50 fetches × ~5 subrequests ≈ 250 + parent overhead → 1000 budget 内に収まる
- 残りの parent は次回 cron で順次拾う設計 (元のコメントのまま)

## 注意

- これは PR #136 の incremental 修正。issue #134 は `Refs` 留めで OPEN を維持し、merge 後 `:15` cron 1-2 周で `fetch_failures=0` を確認してから close する。
- 自律 loop fire #1 (axis-1 follow-up) として実行。Master 起床までに self-review + CI green + self-merge を予定。

Refs #134