### PR TITLE
fix(fts): regenerate AFTER triggers to force re-binding after 0003

### DIFF
--- a/migrations/0004_fts5_triggers_regen.sql
+++ b/migrations/0004_fts5_triggers_regen.sql
@@ -1,0 +1,57 @@
+-- Force re-declaration of FTS5 sync triggers (axis 2 attempt for issue #135)
+--
+-- Layer = L4 Operations (sparse retrieval surface recovery)
+--
+-- Context:
+--   2026-04-28: migration 0003 dropped+recreated search_docs_code_fts to
+--   recover from recurring SQLITE_CORRUPT_VTAB. After 0003 was merged AND
+--   applied via D1 console, production Worker continues to hit
+--   D1_ERROR: SQLITE_CORRUPT_VTAB on every diff upsert (tokenizer_kind=code).
+--   nat_fts surface is clean; code_fts surface persists corrupt across
+--   :30 pollDiffs cron iterations.
+--
+-- Hypothesis:
+--   The AFTER INSERT/UPDATE/DELETE triggers from 0001 were compiled with
+--   references that may need re-resolution after the underlying virtual
+--   table was DROP+CREATEd. Re-declaring the triggers (DROP + CREATE)
+--   forces re-binding to the new search_docs_code_fts.
+--
+-- Scope:
+--   Triggers carry no data (declarative), so this is non-destructive.
+--   Body is byte-for-byte identical to 0001; only the declaration
+--   timing changes.
+--
+-- Idempotency:
+--   DROP IF EXISTS keeps the migration safe to re-run.
+
+DROP TRIGGER IF EXISTS trg_search_docs_ai;
+DROP TRIGGER IF EXISTS trg_search_docs_ad;
+DROP TRIGGER IF EXISTS trg_search_docs_au;
+
+CREATE TRIGGER trg_search_docs_ai AFTER INSERT ON search_docs
+BEGIN
+  INSERT INTO search_docs_nat_fts(rowid, content)
+    SELECT new.rowid, new.content WHERE new.tokenizer_kind = 'nat';
+  INSERT INTO search_docs_code_fts(rowid, content)
+    SELECT new.rowid, new.content WHERE new.tokenizer_kind = 'code';
+END;
+
+CREATE TRIGGER trg_search_docs_ad AFTER DELETE ON search_docs
+BEGIN
+  INSERT INTO search_docs_nat_fts(search_docs_nat_fts, rowid, content)
+    VALUES('delete', old.rowid, old.content);
+  INSERT INTO search_docs_code_fts(search_docs_code_fts, rowid, content)
+    VALUES('delete', old.rowid, old.content);
+END;
+
+CREATE TRIGGER trg_search_docs_au AFTER UPDATE ON search_docs
+BEGIN
+  INSERT INTO search_docs_nat_fts(search_docs_nat_fts, rowid, content)
+    VALUES('delete', old.rowid, old.content);
+  INSERT INTO search_docs_code_fts(search_docs_code_fts, rowid, content)
+    VALUES('delete', old.rowid, old.content);
+  INSERT INTO search_docs_nat_fts(rowid, content)
+    SELECT new.rowid, new.content WHERE new.tokenizer_kind = 'nat';
+  INSERT INTO search_docs_code_fts(rowid, content)
+    SELECT new.rowid, new.content WHERE new.tokenizer_kind = 'code';
+END;


### PR DESCRIPTION
## 観測

- 2026-04-28: migration 0003 (DROP+CREATE `search_docs_code_fts`) を merge し、D1 console で適用済み
- 適用後も production Worker が `D1_ERROR: SQLITE_CORRUPT_VTAB` を `tokenizer_kind=code` の diff upsert で継続報告 (15:30 / 16:30 / 17:30 UTC `pollDiffs` cron)
- nat_fts surface はクリーン (Fire #4-9 で確認)。code_fts surface のみ corrupt が残る

## 仮説

0001 で宣言された `AFTER INSERT/UPDATE/DELETE` trigger は、`search_docs_code_fts` への参照を解決した状態で compile されている。0003 で virtual table を DROP+CREATE した後、trigger が古い参照を保持しているため write が失敗している可能性がある。trigger を DROP + CREATE で再宣言することで、新しい table 実体への再 bind を強制する。

## 変更

- `migrations/0004_fts5_triggers_regen.sql` を追加 (+57 lines)
- 3 つの trigger を DROP IF EXISTS してから CREATE で再宣言
- 各 trigger の body は `0001_fts5_init.sql` と byte-for-byte 同一 (検証済み)
- declarative かつデータを持たないため、非破壊操作

## 適用と検証

- merge は migration を自動適用しない
- 別途 D1 console もしくは `wrangler d1 migrations apply` で 0004 を適用する
- 検証: 適用後の次回 `:30` `pollDiffs` cron で diff upsert が成功するか確認

## Notes

- autonomous loop fire #10 axis 2 attempt 1/3
- root cause は未解決 (axis 1: 0003 で table 再作成 → 失敗。axis 2: trigger 再宣言 = 本 PR)

Refs #135