### PR TITLE
fix(fts): isolate tokenizer indexes during updates

### DIFF
--- a/docs/0-requirements.ja.md
+++ b/docs/0-requirements.ja.md
@@ -208,15 +208,16 @@ D1 の FTS5 virtual table は hybrid retrieval の sparse 側を担う。
 Schema 概要:
 
 - `search_docs` — external content table（source of truth、vector_id を primary key）
-- `search_docs_nat_fts` — porter + unicode61 tokenizer の FTS5 virtual table（自然言語: issue / PR / release / doc）
-- `search_docs_code_fts` — trigram tokenizer の FTS5 virtual table（コード / SHA / identifier: diff）
+- `search_docs_nat_fts_v2` — porter + unicode61 tokenizer の稼働中 FTS5 virtual table（自然言語: issue / PR / release / doc / wiki_doc / comment / review）
+- `search_docs_code_fts_v2` — trigram tokenizer の稼働中 FTS5 virtual table（コード / SHA / identifier: diff）。v1 table は過去の corruption を修復時に触らないため残すが、query / update 対象にはしない
 
 tokenizer 選択:
 
 - `porter` — 自然言語の stem matching に適する
 - `trigram` — SHA prefix、CamelCase、file path などの部分一致に適する
 - tokenizer_kind 列で row をどちらの virtual table に振り分けるか決定
-- content-owner table (`content=search_docs`) + trigger による自動 sync で、delete の fan-out は DELETE FROM search_docs 一発で両 virtual table に伝搬する
+- 各稼働中 FTS table は `search_docs` の tokenizer-filtered view を external-content relation に指定し、宣言上の content row 集合と実際の index row 集合を一致させる。trigger で自動 sync し、すべての分岐を `tokenizer_kind` で guard して、各 row は片方の FTS5 table にだけ insert / delete する。索引したことのない反対側 tokenizer に FTS5 `delete` command を送ることは禁止する（external-content index が壊れるため）
+- 復旧時は新しい FTS generation を作り、`WHERE tokenizer_kind = ...` で各 table を個別 backfill する。FTS5 `rebuild` は全 `search_docs` row を各 tokenizer に流して同じ分離不変条件を壊すため使用しない
 
 vector_id は Vectorize 側と同一（deterministic SHA-256 ベース）で、RRF 合成時に dense hit と sparse hit を追加 round-trip なしで join できる。
 

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -210,15 +210,16 @@ Rationale:
 Schema overview:
 
 - `search_docs` — external content table (source of truth, `vector_id` primary key).
-- `search_docs_nat_fts` — FTS5 virtual table with porter + unicode61 tokenizer for natural-language surfaces (issue / PR / release / doc / wiki_doc / comment / review surfaces).
-- `search_docs_code_fts` — FTS5 virtual table with trigram tokenizer for code / SHA / identifier surfaces (diff).
+- `search_docs_nat_fts_v2` — active FTS5 virtual table with porter + unicode61 tokenizer for natural-language surfaces (issue / PR / release / doc / wiki_doc / comment / review surfaces).
+- `search_docs_code_fts_v2` — active FTS5 virtual table with trigram tokenizer for code / SHA / identifier surfaces (diff). The v1 tables are retained but never queried or updated so a previously corrupt index is not touched during recovery.
 
 Tokenizer selection:
 
 - `porter` — stem-based matching appropriate for natural language.
 - `trigram` — substring matching appropriate for SHA prefixes, CamelCase tokens, and file paths.
 - A `tokenizer_kind` column on `search_docs` decides which virtual table a row is indexed in.
-- `content=search_docs` + triggers cascade inserts / updates / deletes automatically, so `DELETE FROM search_docs` fans out to both FTS5 tables in a single statement.
+- Each active FTS table declares a tokenizer-filtered view of `search_docs` as its external-content relation, so the declared content rows and indexed rows are the same set. Triggers cascade inserts / updates / deletes automatically, and every branch is guarded by `tokenizer_kind`: a row is inserted into and deleted from exactly one FTS5 table. Sending an FTS5 `delete` command to the opposite tokenizer for a row it never indexed is forbidden because it corrupts the external-content index.
+- Recovery creates a fresh FTS generation and backfills each table with a `WHERE tokenizer_kind = ...` filter. It does not use FTS5 `rebuild`, because `rebuild` would copy every `search_docs` row into each tokenizer and violate the same isolation invariant.
 
 The `vector_id` mirrors the Vectorize vector ID (deterministic SHA-256 based) so RRF fusion can join dense and sparse hits without an extra round-trip.
 

--- a/migrations/0005_fts5_tokenizer_isolation.sql
+++ b/migrations/0005_fts5_tokenizer_isolation.sql
@@ -1,0 +1,87 @@
+-- Repair FTS5 tokenizer isolation without touching the corrupted v1 indexes.
+--
+-- Layer = L4 Operations (sparse retrieval surface)
+--
+-- Every search_docs row belongs to exactly one tokenizer index. The original
+-- DELETE and UPDATE triggers sent an FTS5 'delete' command to both indexes,
+-- including the index that had never received the row. FTS5 requires a delete
+-- command to match an existing indexed row exactly; deleting a nonexistent row
+-- leaves the virtual table in an unpredictable state and later bm25() queries
+-- fail with SQLITE_CORRUPT_VTAB.
+--
+-- The existing v1 indexes may already be corrupt in production. Do not rebuild,
+-- drop, or query them here. Create filtered external-content views and new indexes
+-- under fresh shadow-table names, backfill each one from only its tokenizer_kind,
+-- then move the sync triggers to the new generation with the same tokenizer guard
+-- on insert, update, and delete. The views keep each FTS index's declared external
+-- content relation identical to the rows actually present in that index.
+--
+-- The sequence number intentionally skips to 0005. Production retains historical
+-- migration records for removed recovery migrations 0002-0004, so reusing either
+-- number would make Wrangler treat this repair as already applied.
+
+CREATE VIEW IF NOT EXISTS search_docs_nat_content_v2 AS
+  SELECT rowid, content
+    FROM search_docs
+   WHERE tokenizer_kind = 'nat';
+
+CREATE VIEW IF NOT EXISTS search_docs_code_content_v2 AS
+  SELECT rowid, content
+    FROM search_docs
+   WHERE tokenizer_kind = 'code';
+
+CREATE VIRTUAL TABLE IF NOT EXISTS search_docs_nat_fts_v2 USING fts5 (
+  content,
+  tokenize = 'porter unicode61 remove_diacritics 2',
+  content = 'search_docs_nat_content_v2',
+  content_rowid = 'rowid'
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS search_docs_code_fts_v2 USING fts5 (
+  content,
+  tokenize = 'trigram case_sensitive 0',
+  content = 'search_docs_code_content_v2',
+  content_rowid = 'rowid'
+);
+
+INSERT INTO search_docs_nat_fts_v2(rowid, content)
+  SELECT rowid, content
+    FROM search_docs
+   WHERE tokenizer_kind = 'nat';
+
+INSERT INTO search_docs_code_fts_v2(rowid, content)
+  SELECT rowid, content
+    FROM search_docs
+   WHERE tokenizer_kind = 'code';
+
+DROP TRIGGER IF EXISTS trg_search_docs_ai;
+DROP TRIGGER IF EXISTS trg_search_docs_ad;
+DROP TRIGGER IF EXISTS trg_search_docs_au;
+
+CREATE TRIGGER trg_search_docs_ai AFTER INSERT ON search_docs
+BEGIN
+  INSERT INTO search_docs_nat_fts_v2(rowid, content)
+    SELECT new.rowid, new.content WHERE new.tokenizer_kind = 'nat';
+  INSERT INTO search_docs_code_fts_v2(rowid, content)
+    SELECT new.rowid, new.content WHERE new.tokenizer_kind = 'code';
+END;
+
+CREATE TRIGGER trg_search_docs_ad AFTER DELETE ON search_docs
+BEGIN
+  INSERT INTO search_docs_nat_fts_v2(search_docs_nat_fts_v2, rowid, content)
+    SELECT 'delete', old.rowid, old.content WHERE old.tokenizer_kind = 'nat';
+  INSERT INTO search_docs_code_fts_v2(search_docs_code_fts_v2, rowid, content)
+    SELECT 'delete', old.rowid, old.content WHERE old.tokenizer_kind = 'code';
+END;
+
+CREATE TRIGGER trg_search_docs_au AFTER UPDATE ON search_docs
+BEGIN
+  INSERT INTO search_docs_nat_fts_v2(search_docs_nat_fts_v2, rowid, content)
+    SELECT 'delete', old.rowid, old.content WHERE old.tokenizer_kind = 'nat';
+  INSERT INTO search_docs_code_fts_v2(search_docs_code_fts_v2, rowid, content)
+    SELECT 'delete', old.rowid, old.content WHERE old.tokenizer_kind = 'code';
+  INSERT INTO search_docs_nat_fts_v2(rowid, content)
+    SELECT new.rowid, new.content WHERE new.tokenizer_kind = 'nat';
+  INSERT INTO search_docs_code_fts_v2(rowid, content)
+    SELECT new.rowid, new.content WHERE new.tokenizer_kind = 'code';
+END;

--- a/src/fts.ts
+++ b/src/fts.ts
@@ -4,8 +4,8 @@
  * Layer = L4 Operations (sparse retrieval surface)
  *
  * Responsibilities:
- * - Index tokenizable content into the D1 FTS5 virtual tables (`search_docs_nat_fts`,
- *   `search_docs_code_fts`) via the `search_docs` content-owner table.
+ * - Index tokenizable content into the D1 FTS5 virtual tables (`search_docs_nat_fts_v2`,
+ *   `search_docs_code_fts_v2`) via the `search_docs` content-owner table.
  * - Query FTS5 by a natural language or code-oriented query using BM25 ranking.
  * - Delete rows when the canonical surface is removed (issue/PR/release/doc).
  *
@@ -214,7 +214,10 @@ export async function queryFts(
   const whereSql =
     whereClauses.length > 0 ? ` AND ${whereClauses.join(" AND ")}` : "";
 
-  // Two UNION ALL branches so each tokenizer contributes hits. The outer ORDER BY
+  // Two UNION ALL branches so each tokenizer contributes hits. The v2 indexes
+  // were created by migration 0005 with tokenizer-isolated delete/update
+  // triggers; the v1 indexes are intentionally left untouched because either
+  // one may already contain invalid delete entries. The outer ORDER BY
   // then picks the best BM25 score across both. `bm25()` returns negative values
   // in D1's FTS5 (larger-magnitude negative = better match), so ASC orders
   // best-first regardless of sign.
@@ -230,10 +233,10 @@ export async function queryFts(
                d.milestone, d.assignees, d.updated_at,
                d.number, d.tag_name, d.doc_path, d.commit_sha, d.file_path, d.file_status,
                d.commit_date, d.commit_author, d.content,
-               bm25(search_docs_nat_fts) AS score
-          FROM search_docs_nat_fts f
+               bm25(search_docs_nat_fts_v2) AS score
+          FROM search_docs_nat_fts_v2 f
           JOIN search_docs d ON d.rowid = f.rowid
-         WHERE search_docs_nat_fts MATCH ?${whereSql}
+         WHERE search_docs_nat_fts_v2 MATCH ?${whereSql}
          ORDER BY score ASC
          LIMIT ?
       )
@@ -243,10 +246,10 @@ export async function queryFts(
                d.milestone, d.assignees, d.updated_at,
                d.number, d.tag_name, d.doc_path, d.commit_sha, d.file_path, d.file_status,
                d.commit_date, d.commit_author, d.content,
-               bm25(search_docs_code_fts) AS score
-          FROM search_docs_code_fts f
+               bm25(search_docs_code_fts_v2) AS score
+          FROM search_docs_code_fts_v2 f
           JOIN search_docs d ON d.rowid = f.rowid
-         WHERE search_docs_code_fts MATCH ?${whereSql}
+         WHERE search_docs_code_fts_v2 MATCH ?${whereSql}
          ORDER BY score ASC
          LIMIT ?
       )

--- a/src/fts.workers.test.ts
+++ b/src/fts.workers.test.ts
@@ -96,6 +96,115 @@ describe("fts D1: deleteFtsRow", () => {
   });
 });
 
+describe("fts D1: tokenizer isolation", () => {
+  it("keeps the opposite tokenizer healthy across updates and deletes", async () => {
+    const repo = "t/tokenizer-isolation";
+    const natId = "i:tokenizer-isolation";
+    const codeId = "c:tokenizer-isolation";
+
+    await upsertFtsRow(
+      env.DB_FTS,
+      mkRow({ vectorId: natId, type: "issue", repo, content: "persistent natural-language sentinel" }),
+    );
+    await upsertFtsRow(
+      env.DB_FTS,
+      mkRow({ vectorId: codeId, type: "diff", repo, content: "persistentCodeSentinel" }),
+    );
+
+    await upsertFtsRow(
+      env.DB_FTS,
+      mkRow({ vectorId: natId, type: "issue", repo, content: "updated natural-language sentinel" }),
+    );
+    await deleteFtsRow(env.DB_FTS, natId);
+    expect((await queryFts(env.DB_FTS, "CodeSentinel", 10, { repo })).map((h) => h.vectorId))
+      .toContain(codeId);
+
+    await upsertFtsRow(
+      env.DB_FTS,
+      mkRow({ vectorId: codeId, type: "diff", repo, content: "updatedCodeSentinel" }),
+    );
+    await deleteFtsRow(env.DB_FTS, codeId);
+    await upsertFtsRow(
+      env.DB_FTS,
+      mkRow({ vectorId: `${natId}-survivor`, type: "issue", repo, content: "healthy natural tokenizer" }),
+    );
+    expect((await queryFts(env.DB_FTS, "healthy", 10, { repo })).map((h) => h.vectorId))
+      .toContain(`${natId}-survivor`);
+  });
+});
+
+describe("fts D1: v1 corruption recovery migration", () => {
+  it("backfills healthy v2 indexes without reading the corrupt v1 indexes", async () => {
+    const baseMigration = env.TEST_MIGRATIONS.find((m) => m.name === "0001_fts5_init.sql");
+    const repairMigration = env.TEST_MIGRATIONS.find(
+      (m) => m.name === "0005_fts5_tokenizer_isolation.sql",
+    );
+    expect(baseMigration).toBeDefined();
+    expect(repairMigration).toBeDefined();
+
+    await applyD1Migrations(env.DB_FTS_MIGRATION, [baseMigration!]);
+
+    const repo = "t/v1-recovery";
+    const natId = "i:v1-recovery";
+    const codeId = "c:v1-recovery";
+    await upsertFtsRow(
+      env.DB_FTS_MIGRATION,
+      mkRow({ vectorId: codeId, type: "diff", repo, content: "persistentCodeSentinel" }),
+    );
+    await upsertFtsRow(
+      env.DB_FTS_MIGRATION,
+      mkRow({ vectorId: natId, type: "issue", repo, content: "original natural sentinel" }),
+    );
+
+    // The v1 UPDATE trigger sends a delete command to code_fts even though this
+    // nat row was never indexed there. D1 rejects the write as a corrupt-vtab
+    // operation; sparse mirroring can therefore never reconcile this row.
+    await expect(
+      upsertFtsRow(
+        env.DB_FTS_MIGRATION,
+        mkRow({ vectorId: natId, type: "issue", repo, content: "updated natural sentinel" }),
+      ),
+    ).rejects.toThrow(/SQLITE_CORRUPT_VTAB/);
+
+    await applyD1Migrations(env.DB_FTS_MIGRATION, [repairMigration!]);
+
+    await env.DB_FTS_MIGRATION
+      .prepare(
+        "INSERT INTO search_docs_nat_fts_v2(search_docs_nat_fts_v2, rank) VALUES('integrity-check', 1)",
+      )
+      .run();
+    await env.DB_FTS_MIGRATION
+      .prepare(
+        "INSERT INTO search_docs_code_fts_v2(search_docs_code_fts_v2, rank) VALUES('integrity-check', 1)",
+      )
+      .run();
+
+    expect(
+      (await queryFts(env.DB_FTS_MIGRATION, "CodeSentinel", 10, { repo }))
+        .map((h) => h.vectorId),
+    ).toContain(codeId);
+    expect(
+      (await queryFts(env.DB_FTS_MIGRATION, "original", 10, { repo }))
+        .map((h) => h.vectorId),
+    ).toContain(natId);
+
+    await upsertFtsRow(
+      env.DB_FTS_MIGRATION,
+      mkRow({ vectorId: natId, type: "issue", repo, content: "updated natural sentinel" }),
+    );
+    expect(
+      (await queryFts(env.DB_FTS_MIGRATION, "updated", 10, { repo }))
+        .map((h) => h.vectorId),
+    ).toContain(natId);
+
+    await deleteFtsRow(env.DB_FTS_MIGRATION, natId);
+    expect(
+      (await queryFts(env.DB_FTS_MIGRATION, "CodeSentinel", 10, { repo }))
+        .map((h) => h.vectorId),
+    ).toContain(codeId);
+  });
+});
+
 describe("fts D1: structured filters", () => {
   it("filters by repo", async () => {
     await upsertFtsRow(env.DB_FTS, mkRow({ vectorId: "i:repo-a", type: "issue", repo: "t/repo-alpha", content: "shared keyword token" }));

--- a/src/test-env.d.ts
+++ b/src/test-env.d.ts
@@ -13,6 +13,7 @@ interface TestD1Migration {
 declare module "cloudflare:test" {
   interface ProvidedEnv {
     DB_FTS: D1Database;
+    DB_FTS_MIGRATION: D1Database;
     TEST_MIGRATIONS: TestD1Migration[];
     ISSUE_STORE: DurableObjectNamespace<import("./store.js").IssueStore>;
   }

--- a/vitest.workers.config.ts
+++ b/vitest.workers.config.ts
@@ -23,7 +23,10 @@ export default defineConfig(async () => {
     miniflare: {
       compatibilityDate: "2025-03-26",
       compatibilityFlags: ["nodejs_compat"],
-      d1Databases: { DB_FTS: "test-fts" },
+      d1Databases: {
+        DB_FTS: "test-fts",
+        DB_FTS_MIGRATION: "test-fts-migration",
+      },
       durableObjects: {
         ISSUE_STORE: { className: "IssueStore", useSQLite: true },
       },


### PR DESCRIPTION
Closes #174
存在しない反対側 tokenizer row への FTS5 delete command を止め、nat/code の index 集合を分離する。
corrupt 済み v1 を触らず filtered view から v2 へ backfill する migration と回帰テストを追加する。